### PR TITLE
feat: runtime API added

### DIFF
--- a/rpc/runtime-api/Cargo.toml
+++ b/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pallet-move-runtime-api"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+edition = "2021"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive",] }
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"sp-api/std",
+]

--- a/rpc/runtime-api/src/lib.rs
+++ b/rpc/runtime-api/src/lib.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::weights::Weight;
+
+// Here we declare the runtime API. It is implemented it the `impl` block in
+// runtime file (the `runtime/src/lib.rs` of the node)
+sp_api::decl_runtime_apis! {
+    pub trait MoveApi<AccountId> where      // AccountID is already here for the next API calls.
+        AccountId: codec::Codec,
+    {
+        // Convert Weight to Gas.
+        fn gas_to_weight(gas_limit: u64) -> Weight;
+
+        // Convert Gas to Weight.
+        fn weight_to_gas(weight: Weight) -> u64;
+
+    }
+}


### PR DESCRIPTION
Crate with runtime API has been added, providing ability to call some commands from the runtime.

This can be used by other crates (like RPC crate) to call runtime functions when eg. they receive specific RPC query.

To compile properly this trait needs to be implemented in the `impl` block in runtime file (the `runtime/src/lib.rs` file of the node).