### PR TITLE
feat: RPC crate

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "pallet-move-rpc"
+version = "0.1.0"
+authors = ["Eiger <hello@eiger.co>"]
+edition = "2021"
+description = 'RPC methods for the Move pallet'
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive",] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
+
+# Substrate packages
+frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-runtime = { default-features = false, version = "24.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+
+# local packages
+pallet-move-runtime-api = { path = "./runtime-api", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+  "sp-api/std",
+  "sp-runtime/std",
+  "pallet-move-runtime-api/std"
+]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use codec::Codec;
+use frame_support::weights::Weight;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+pub use pallet_move_runtime_api::MoveApi as MoveRuntimeApi;
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::Block as BlockT;
+
+/// Public RPC API of the Move pallet.
+#[rpc(server)]
+pub trait MoveApi<BlockHash, AccountId> {
+    /// Convert gas to weight
+    #[method(name = "mvm_gasToWeight")]
+    fn gas_to_weight(&self, gas: u64, at: Option<BlockHash>) -> RpcResult<Weight>;
+
+    /// Convert weight to gas
+    #[method(name = "mvm_weightToGas")]
+    fn weight_to_gas(&self, weight: Weight, at: Option<BlockHash>) -> RpcResult<u64>;
+}
+
+/// A struct that implements the `MoveApi`.
+pub struct MovePallet<C, Block> {
+    client: Arc<C>,
+    _marker: std::marker::PhantomData<Block>,
+}
+
+impl<C, Block> MovePallet<C, Block> {
+    /// Create new `MovePallet` instance with the given reference to the client.
+    pub fn new(client: Arc<C>) -> Self {
+        Self {
+            client,
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<C, Block, AccountId> MoveApiServer<<Block as BlockT>::Hash, AccountId> for MovePallet<C, Block>
+where
+    Block: BlockT,
+    AccountId: Clone + std::fmt::Display + Codec,
+    C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+    C::Api: MoveRuntimeApi<Block, AccountId>,
+{
+    fn gas_to_weight(&self, gas: u64, at: Option<<Block as BlockT>::Hash>) -> RpcResult<Weight> {
+        // Return a dummy weight for now
+        Ok(Weight::from_parts(2_123_123, 0))
+    }
+
+    fn weight_to_gas(&self, weight: Weight, at: Option<<Block as BlockT>::Hash>) -> RpcResult<u64> {
+        // Return a dummy gas for now
+        Ok(1u64)
+    }
+}


### PR DESCRIPTION
This crate is used to expose RPC public API and call runtime functions, receive results and pass it back to the RPC caller.

Currently it contains two RPC stubs that return hardcoded values to use them for testing purposes.