### PR TITLE
doc: use template node with pallet included

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ MoveVM pallet for Substrate-based chains
 
 # Running pallet from the substrate-node
 
-## Substrate-node
+## Substrate-node with Move pallet
 To spin up the local development node follow instructions from the [official guide](https://docs.substrate.io/tutorials/build-a-blockchain/build-local-blockchain/).
 
 The most important steps are described below.
 
-1. Clone node-template and switch to the newest branch:
+1. Clone Move pallet and node-template (make sure they are in the same repository) and switch to the newest branch which already include Move pallet building:
 ```bash
+git clone https://github.com/eigerco/pallet-move.git
 git clone https://github.com/eigerco/substrate-node-template
 cd substrate-node-template
-git checkout polkadot-v1.0.0
+git checkout polkadot-1.0.0-pallet-move
 ```
 
-2. Create a new branch and build the node:
+2. Create a new branch (if you are going to make new changes) and build the node:
 ```bash
 git checkout -b move-vm-pallet
 cargo build --release
@@ -55,59 +56,16 @@ Congratulations! You've spun up your first Substrate node. You are able now to p
 5. when everything is completed you will see information that the transaction has been successful along with `tx hash` value;
 6. `Balances` section should now display new balances for the affected accounts.
 
-## Adding MoveVM pallet to the node
+Check if the Move pallet is available in the frontend. If yes, there is possibility to call `execute` extrinsic and observe emitted events. 
 
-1. Go to the substrate-based node directory root.
-
-2. Open the `runtime/Cargo.toml` file and add a new dependency:
-```toml
-pallet-move = { default-features = false, path = "../../pallet-move" }
+To check if there are RPC calls available run:
+```bash
+curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "mvm_gasToWeight", "params": [123]}' http://localhost:9944/
 ```
-and under the `[features]` section, to the `std` section, add this feature:
-```toml
-std = [
-    <...>
-    "pallet-move/std",
-]
+You should see the correct response with some value like:
+```bash
+{"jsonrpc":"2.0","result":{"ref_time":2123123,"proof_size":0},"id":1}
 ```
-to the `runtime-benchmarks` section, add this feature:
-```toml
-runtime-benchmarks = [
-    <...>
-    "pallet-move/runtime-benchmarks",
-]
-```
-and to the `try-runtime = [` section, add this feature.
-```toml
-try-runtime = [
-    <...>
-    "pallet-move/try-runtime",
-]
-```
-The instructions here assume that the `pallet-move` and the `substrate-node-template` repos are located under the same directory.
-
-3. Open `runtime/src/lib.rs` and add new pallet to the runtime configuration.
-Add new import:
-```rust
-pub use pallet-move;
-```
-Find section where pallets are configured for Runtime and add new pallet:
-```rust
-impl pallet_move::Config for Runtime {
-        type RuntimeEvent = RuntimeEvent;
-        type WeightInfo = pallet_move::weights::SubstrateWeight<Runtime>;
-}
-```
-Add new pallet under `construct_runtime!(` macro:
-```rust
-    MoveModule: pallet_move,
-```
-If you need to run runtime benchmarks find `define_benchmarks!(` macro and add:
-```rust
-    [pallet_move, MoveModule]
-```
-
-4. Re-build the node, run the node and the frontend, then check if the pallet is available in the frontend. If yes, there is possibility to call `execute` extrinsic and observe emitted events.
 
 ## Benchmarking
 Benchmarking and updating weights should be done each time new extrinsic is added to the pallet (weights are used to estimate transaction fees). Weights are obligatory for extrinsics that are available for users.


### PR DESCRIPTION
Setting up Move pallet is now much simplier as user can use already prepared template node which includes building of the external Move pallet.

All the user need is to put node and Move pallet in the same directory and run node building.