### PR TITLE
feat: runtime storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, git = "https:
 frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 sp-std = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v1.0.0' }
 
-# Just for the proof of concept - the no-std move-core-types crate is compatible with our pallet
-move-core-types = { git = "https://github.com/eigerco/substrate-move.git", default-features = false }
+move-vm-backend = { default-features = false, git = 'https://github.com/eigerco/substrate-move.git' }
 
 [dev-dependencies]
 sp-core = { version = "21.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
@@ -36,7 +35,7 @@ std = [
     "frame-system/std",
     "scale-info/std",
     "sp-std/std",
-    "move-core-types/std",
+    "move-vm-backend/std",
 ]
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,49 @@
+use core::marker::PhantomData;
+
+use codec::{FullCodec, FullEncode};
+use frame_support::storage::StorageMap;
+use move_vm_backend::storage::Storage;
+use sp_std::prelude::*;
+
+/// Move Virtual Machine storage trait used to represent the native storage.
+pub trait MoveVmStorage<T, K: FullEncode, V: FullCodec> {
+    type VmStorage;
+
+    /// Create a new instance of the VM storage.
+    fn move_vm_storage() -> StorageAdapter<Self::VmStorage, K, V>
+    where
+        Self::VmStorage: StorageMap<K, V, Query = Option<V>>,
+    {
+        Default::default()
+    }
+}
+
+/// Vm storage adapter for native storage.
+pub struct StorageAdapter<T, K = Vec<u8>, V = Vec<u8>>(PhantomData<(T, K, V)>);
+
+/// Default trait VM storage adapter implementation
+impl<T, K, V> Default for StorageAdapter<T, K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+/// Storage trait implementation for the StorageAdapter struct.
+impl<T: StorageMap<Vec<u8>, Vec<u8>, Query = Option<Vec<u8>>>> Storage
+    for StorageAdapter<T, Vec<u8>, Vec<u8>>
+{
+    /// Get a value specified by key.
+    fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        T::get(key)
+    }
+
+    /// Set (insert) a value specified by key.
+    fn set(&self, key: &[u8], value: &[u8]) {
+        T::insert(key, value)
+    }
+
+    /// Remove a value specified by key and the key itself.
+    fn remove(&self, key: &[u8]) {
+        T::remove(key)
+    }
+}


### PR DESCRIPTION
This code adds storage items for the pallet (StorageMap). Moreover, it adds impl block for the Move storage for the current Pallet with our configuration.

That PR contains a complementary Storage module based on Pontem's solution. Currently, it implements the main Move storage trait and storage adapter. Both are used to create storage impl for Pallet, as mentioned above.

That's initial support of storage, as it needs to be initialized when a real VM is created inside the pallet.