### PR TITLE
feat: impl publish_module_bundle

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -158,8 +158,8 @@ Let's dive into the crucial aspects of pallet architecture:
 3) Storage: It defines the data structures and how they are accessed and modified. The MoveVM pallet would use it to store data in the map of key-value pairs and provide a storage adapter for the Move Virtual Machine storage.
 4) Dispatchable Functions - extrinsics: The MoveVM pallet will expose dispatchable functions, which users can call via transactions. Currently, there are three extrinsics defined:
 - 'execute' - executes a Move script;
-- 'publishModule' - publishes a Move module;
-- 'publishPackage' - publishes a Move package.
+- 'publish_module' - publishes a Move module;
+- 'publish_module_bundle' - publishes a bundle of Move modules.
 5) Events: Events inform about changes within the pallet. The MoveVM pallet defines separate events for completing each extrinsic call. Somebody can subscribe to them, allowing external applications to react to specific changes or triggers within the blockchain.
 6) Configuration: The MoveVM pallet is configured during the runtime's setup to customize its behaviour. Configuration is done in a standard way, like it's done for other pallets.
 7) Traits: The MoveVM pallet defines a set of traits which can be used further in the runtime or RPC node.

--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -31,12 +31,12 @@ mod benchmarks {
     }
 
     #[benchmark]
-    fn publish_package() {
+    fn publish_module_bundle() {
         let caller: T::AccountId = whitelisted_caller();
         let module =
             include_bytes!("../tests/assets/move/build/move/bytecode_modules/Empty.mv").to_vec();
         #[extrinsic_call]
-        publish_package(RawOrigin::Signed(caller), module, 1_500_000);
+        publish_module_bundle(RawOrigin::Signed(caller), module, 1_500_000);
     }
 
     impl_benchmark_test_suite!(MovePallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -37,7 +37,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn execute() -> Weight;
 	fn publish_module() -> Weight;
-	fn publish_package() -> Weight;
+	fn publish_module_bundle() -> Weight;
 }
 
 /// Weights for pallet_move using the Substrate node and recommended hardware.
@@ -57,7 +57,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 5_284_000 picoseconds.
 		Weight::from_parts(5_814_000, 0)
 	}
-	fn publish_package() -> Weight {
+	fn publish_module_bundle() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
@@ -82,7 +82,7 @@ impl WeightInfo for () {
 		// Minimum execution time: 5_284_000 picoseconds.
 		Weight::from_parts(5_814_000, 0)
 	}
-	fn publish_package() -> Weight {
+	fn publish_module_bundle() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`


### PR DESCRIPTION
- Allow publishing module bundles
- Renaming package to bundle
   - So, for a set of modules, we'll use the term bundle instead of package(which can interfere with a Module Package term)

TODO:
 - tests for this extrinsic