### PR TITLE
 deps: use release-polkadot-v1.4.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,25 +14,26 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
 bcs = { git = "https://github.com/eigerco/bcs.git", default-features = false, branch = "master" }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive",] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-sp-std = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v1.0.0' }
+codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10", default-features = false, features = ["derive"] }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+sp-std = { default-features = false, git = 'https://github.com/paritytech/polkadot-sdk.git', branch = 'release-polkadot-v1.4.0' }
 
 # MoveVM dependencies
-move-core-types = { default-features = false, git = 'https://github.com/eigerco/substrate-move.git', features = ["address32"] }
+move-core-types = { default-features = false, git = 'https://github.com/eigerco/substrate-move.git', branch = "main", features = ["address32"] }
 
 # MoveVM backend dependency
-move-vm-backend = { default-features = false, git = 'https://github.com/eigerco/substrate-move.git' }
+move-vm-backend = { default-features = false, git = 'https://github.com/eigerco/substrate-move.git', branch = "main" }
 
 [dev-dependencies]
 hex = "0.4"
-sp-core = { version = "21.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-io = { version = "23.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { version = "24.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
 
 [features]
 default = ["std"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -9,14 +9,14 @@ description = 'RPC methods for the Move pallet'
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive",] }
-jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
+codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = ["derive"] }
+jsonrpsee = { version = "0.16", features = ["server", "macros"] }
 
 # Substrate packages
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, version = "24.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+sp-api = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+sp-blockchain = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
 
 # local packages
 pallet-move-runtime-api = { path = "./runtime-api", default-features = false }

--- a/rpc/runtime-api/Cargo.toml
+++ b/rpc/runtime-api/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive",] }
-frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/rpc/runtime-api/src/lib.rs
+++ b/rpc/runtime-api/src/lib.rs
@@ -2,8 +2,8 @@
 
 extern crate alloc;
 
-use frame_support::{dispatch::Vec, weights::Weight};
-use alloc::string::String;
+use frame_support::weights::Weight;
+use alloc::{string::String, vec::Vec};
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime file (the `runtime/src/lib.rs` of the node)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use codec::Codec;
-use frame_support::{dispatch::Vec, weights::Weight};
+use frame_support::weights::Weight;
 use jsonrpsee::{
     core::{Error as JsonRpseeError, RpcResult},
     proc_macros::rpc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,11 @@ pub mod pallet {
     use alloc::format;
 
     use codec::{FullCodec, FullEncode};
-    use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
+    use frame_support::{
+        dispatch::DispatchResultWithPostInfo,
+        pallet_prelude::*,
+        traits::{Currency, ReservableCurrency},
+    };
     use frame_system::pallet_prelude::*;
     use move_core_types::account_address::AccountAddress;
     use move_vm_backend::{types::GasStrategy, Mvm};
@@ -50,8 +54,12 @@ pub mod pallet {
     pub trait Config: frame_system::Config {
         /// Because this pallet emits events, it depends on the runtime's definition of an event.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
         /// Type representing the weight of this pallet
         type WeightInfo: WeightInfo;
+
+        /// The currency mechanism.
+        type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
     }
 
     // Pallets use events to inform users when important changes are made.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,9 +1,10 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::convert::TryFrom;
 
 //TODO: either leave it as is when moving to move-vm-backend (then remove this comment) or
 // change it to crate error type
 use anyhow::Error;
-use frame_support::dispatch::Vec;
 use move_core_types::language_storage::TypeTag;
 use serde::{Deserialize, Serialize};
 

--- a/tests/execute.rs
+++ b/tests/execute.rs
@@ -4,6 +4,8 @@ use mock::*;
 use move_core_types::language_storage::TypeTag;
 use pallet_move::transaction::Transaction;
 
+const INFINITE_GAS: u64 = u64::MAX;
+
 #[test]
 /// Test execution of a script.
 fn execute_script_empty() {
@@ -22,7 +24,11 @@ fn execute_script_empty() {
 
         let transaction_bc = bcs::to_bytes(&transaction).unwrap();
 
-        let res = MoveModule::execute(RuntimeOrigin::signed(0xFECA000000000000), transaction_bc, 0);
+        let res = MoveModule::execute(
+            RuntimeOrigin::signed(0xFECA000000000000),
+            transaction_bc,
+            INFINITE_GAS,
+        );
 
         assert_ok!(res);
 
@@ -40,7 +46,11 @@ fn execute_script_empty() {
 
         let transaction_bc = bcs::to_bytes(&transaction).unwrap();
 
-        let res = MoveModule::execute(RuntimeOrigin::signed(0xFECA000000000000), transaction_bc, 0);
+        let res = MoveModule::execute(
+            RuntimeOrigin::signed(0xFECA000000000000),
+            transaction_bc,
+            INFINITE_GAS,
+        );
 
         assert_ok!(res);
     });
@@ -65,7 +75,11 @@ fn execute_script_params() {
 
         let transaction_bc = bcs::to_bytes(&transaction).unwrap();
 
-        let res = MoveModule::execute(RuntimeOrigin::signed(0xFECA000000000000), transaction_bc, 0);
+        let res = MoveModule::execute(
+            RuntimeOrigin::signed(0xFECA000000000000),
+            transaction_bc,
+            INFINITE_GAS,
+        );
 
         assert_ok!(res);
     });
@@ -90,7 +104,11 @@ fn execute_script_generic() {
 
         let transaction_bc = bcs::to_bytes(&transaction).unwrap();
 
-        let res = MoveModule::execute(RuntimeOrigin::signed(0xFECA000000000000), transaction_bc, 0);
+        let res = MoveModule::execute(
+            RuntimeOrigin::signed(0xFECA000000000000),
+            transaction_bc,
+            INFINITE_GAS,
+        );
 
         assert_ok!(res);
     });

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -1,4 +1,4 @@
-use frame_support::traits::{ConstU16, ConstU64};
+use frame_support::traits::{ConstU128, ConstU16, ConstU32, ConstU64};
 use sp_core::H256;
 use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
@@ -24,7 +24,7 @@ impl frame_system::Config for Test {
     type BlockHashCount = ConstU64<250>;
     type Version = ();
     type PalletInfo = PalletInfo;
-    type AccountData = ();
+    type AccountData = pallet_balances::AccountData<Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type SystemWeightInfo = ();
@@ -33,9 +33,32 @@ impl frame_system::Config for Test {
     type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
+pub type Balance = u128;
+pub const EXISTENTIAL_DEPOSIT: u128 = 500;
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = ConstU32<50>;
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    /// The type for recording an account's balance.
+    type Balance = Balance;
+    /// The ubiquitous event type.
+    type RuntimeEvent = RuntimeEvent;
+    type DustRemoval = ();
+    type ExistentialDeposit = ConstU128<EXISTENTIAL_DEPOSIT>;
+    type AccountStore = System;
+    type WeightInfo = pallet_balances::weights::SubstrateWeight<Test>;
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
+    type RuntimeHoldReason = ();
+    type MaxHolds = ();
+    type RuntimeFreezeReason = ();
+}
+
 impl pallet_move::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
+    type Currency = Balances;
 }
 
 // Build genesis storage according to the mock runtime.
@@ -52,6 +75,7 @@ frame_support::construct_runtime!(
     pub enum Test
     {
         System: frame_system,
+        Balances: pallet_balances,
         MoveModule: pallet_move,
     }
 );


### PR DESCRIPTION
- Bumping the polkasdk in the pallet from
`release-polkadot-v1.0.0` to `release-polkadot-v1.4.0`.
- `type Currency` added to `frame_system::Config`
- one other commit included: `chore: fix execute tests with some gas`

