### PR TITLE
feat: enable estimate gas for script execution

### DIFF
--- a/rpc/runtime-api/src/lib.rs
+++ b/rpc/runtime-api/src/lib.rs
@@ -23,22 +23,22 @@ sp_api::decl_runtime_apis! {
         // Convert Gas to Weight.
         fn weight_to_gas(weight: Weight) -> u64;
 
-        // Estimate gas for publish module.
+        // Estimate gas for publishing a module.
         fn estimate_gas_publish_module(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, sp_runtime::DispatchError>;
 
-        // Estimate gas for publish bundle.
+        // Estimate gas for publishing a bundle.
         fn estimate_gas_publish_bundle(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, sp_runtime::DispatchError>;
 
-        // Estimate gas for execute script.
-        fn estimate_gas_execute(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, sp_runtime::DispatchError>;
+        // Estimate gas for script execution.
+        fn estimate_gas_execute_script(account: AccountId, transaction: Vec<u8>, cheque_limit: u128) -> Result<MoveApiEstimation, sp_runtime::DispatchError>;
 
-        // Get module binary by its address
+        // Get module binary by its address.
         fn get_module(address: String, name: String) -> Result<Option<Vec<u8>>, Vec<u8>>;
 
-        // Get module ABI by its address
+        // Get module ABI by its address.
         fn get_module_abi(address: String, name: String) -> Result<Option<ModuleAbi>, Vec<u8>>;
 
-        // Get resource
+        // Get resource.
         fn get_resource(account: AccountId, tag: Vec<u8>) -> Result<Option<Vec<u8>>, Vec<u8>>;
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -62,11 +62,12 @@ pub trait MoveApi<BlockHash, AccountId> {
     ) -> RpcResult<Estimation>;
 
     /// Estimate gas for executing Move script.
-    #[method(name = "mvm_estimateGasExecute")]
-    fn estimate_gas_execute(
+    #[method(name = "mvm_estimateGasExecuteScript")]
+    fn estimate_gas_execute_script(
         &self,
         account: AccountId,
-        bytecode: Vec<u8>,
+        transaction: Vec<u8>,
+        cheque_limit: u128,
         at: Option<BlockHash>,
     ) -> RpcResult<Estimation>;
 
@@ -175,18 +176,20 @@ where
         Ok(Estimation::from(move_api_estimation))
     }
 
-    fn estimate_gas_execute(
+    fn estimate_gas_execute_script(
         &self,
         account: AccountId,
-        bytecode: Vec<u8>,
+        transaction: Vec<u8>,
+        cheque_limit: u128,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Estimation> {
         let api = self.client.runtime_api();
         let res = api
-            .estimate_gas_execute(
+            .estimate_gas_execute_script(
                 at.unwrap_or_else(|| self.client.info().best_hash),
                 account,
-                bytecode,
+                transaction,
+                cheque_limit,
             )
             .map_err(runtime_error_into_rpc_err)?;
 

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -103,7 +103,9 @@ where
 
     /// Executes the true transactions on the blockchain/substrate side after execution of
     /// Move-script.
-    pub fn apply_transactions(&self) -> DispatchResult {
+    ///
+    /// Important note: This can only be called from within the pallet.
+    pub(super) fn apply_transactions(&self) -> DispatchResult {
         let zero = BalanceOf::<T>::zero();
 
         self.cmp_with_initial_state()?;

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -30,7 +30,7 @@ where
     BalanceOf<T>: From<u128> + Into<u128>,
 {
     /// Creates a new [`ScriptSignatureHandler`] with all blank signatures for the provided script.
-    pub(crate) fn new(script_args: &[Vec<u8>], signer_count: usize) -> Result<Self, Error<T>> {
+    pub(crate) fn new(script_args: &[&[u8]], signer_count: usize) -> Result<Self, Error<T>> {
         if signer_count > script_args.len() {
             return Err(Error::ScriptSignatureFailure);
         }


### PR DESCRIPTION
Gas script-execution estimation requires only three parameters:
- `account` (simulating the account that will sign the extrinsic)
- `transaction` (blob packed with necessary script parameters and the script bytecode)
- `cheque_limit` (simulation for balance status access without write rights)

Included in this change:
- updates to RPC modules
- prepared `raw_execute_script', which can be called from the runtime RPC module in a read_only fashion.