### PR TITLE
feat: add move-project for multiple signers

### DIFF
--- a/tests/assets/move-projects/multiple-signers/Move.toml
+++ b/tests/assets/move-projects/multiple-signers/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "multiple-signers"
+version = "0.1.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/eigerco/substrate-move.git", subdir = "language/move-stdlib", rev = "main" }
+substrate-stdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
+
+[addresses]
+std =  "0x1"
+substrate = "0x1"
+DeveloperBob = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"

--- a/tests/assets/move-projects/multiple-signers/build.sh
+++ b/tests/assets/move-projects/multiple-signers/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+cd $(dirname $0)
+# Participants SS58-addresses.
+BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
+ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+CHARLIE=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
+EVE=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
+# Build the Move sources.
+smove build
+# Generate script-transactions.
+# 1. init_module(Bob)
+smove create-transaction --compiled-script-path build/multiple-signers/bytecode_scripts/init_module.mv --args signer:$BOB
+# 2. rent_apartment(Alice, Alice-Stash, Bob-Stash)
+smove create-transaction --compiled-script-path build/multiple-signers/bytecode_scripts/rent_apartment.mv --args signer:$ALICE signer:$CHARLIE signer:$EVE

--- a/tests/assets/move-projects/multiple-signers/estimate.sh
+++ b/tests/assets/move-projects/multiple-signers/estimate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+CHARLIE=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
+EVE=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
+
+STUDENTS=5D6pX37Vm8umrtaBah3q7unW3zuatQ3wJrpsXVsi8xxeBJgB
+
+smove node rpc estimate-gas-execute-script -a $ALICE -s build/multiple-signers/script_transactions/rent_apartment.mvt --cheque-limit 100000000000000
+

--- a/tests/assets/move-projects/multiple-signers/sources/Dorm.move
+++ b/tests/assets/move-projects/multiple-signers/sources/Dorm.move
@@ -1,0 +1,70 @@
+/// Bob's dorm. He offers several hireable flats / apartments for student groups.
+module DeveloperBob::Dorm {
+    use std::signer;
+    use std::vector;
+    use substrate::balance;
+
+    /// Address of the owner of this module.
+    const MODULE_OWNER: address = @DeveloperBob;
+
+    /// Simple solution, fixed price for a flat per month. 
+    const FLAT_PRICE_PM: u128 = 90000000000000; // equals 90 UNIT
+
+    /// Error codes.
+    const NOT_MODULE_OWNER: u64 = 0;
+    const MODULE_NOT_INITIALIZED: u64 = 1;
+    const MODULE_ALREADY_INITIALIZED: u64 = 2;
+    const NOT_ENOUGH_MONEY: u64 = 3;
+
+    /// Group of students, which rent a flat together.
+    struct Group has store {
+        list: vector<address>
+    }
+
+    /// All tenant groups will be registered here.
+    struct Dorm has key {
+        groups: vector<Group>
+    }
+
+    /// Initialization method for module owner.
+    public fun init_module(module_owner: &signer) {
+        assert!(signer::address_of(module_owner) == MODULE_OWNER, NOT_MODULE_OWNER);
+        assert!(!exists<Dorm>(signer::address_of(module_owner)), MODULE_ALREADY_INITIALIZED);
+        move_to(module_owner, Dorm { groups: vector::empty<Group>() });
+    }
+
+    /// Creates a new tenant group and signs a rental agreement.
+    public fun rent_apartment(
+        student1: &signer,
+        student2: &signer,
+        student3: &signer,
+        months: u8) acquires Dorm
+    {
+        assert!(exists<Dorm>(MODULE_OWNER), MODULE_NOT_INITIALIZED);
+
+        // Check that all of the students have enough money.
+        let per_person = FLAT_PRICE_PM * (months as u128) / 3;
+
+        let address1 = signer::address_of(student1);
+        let address2 = signer::address_of(student2);
+        let address3 = signer::address_of(student3);
+
+        assert!(balance::cheque_amount(address1) >= per_person, NOT_ENOUGH_MONEY);
+        assert!(balance::cheque_amount(address2) >= per_person, NOT_ENOUGH_MONEY);
+        assert!(balance::cheque_amount(address3) >= per_person, NOT_ENOUGH_MONEY);
+
+        // Transfer the money and register the new tenant group.
+        balance::transfer(student1, MODULE_OWNER, per_person);
+        balance::transfer(student2, MODULE_OWNER, per_person);
+        balance::transfer(student3, MODULE_OWNER, per_person);
+
+        let list = vector::empty<address>();
+        vector::push_back(&mut list, address1);
+        vector::push_back(&mut list, address2);
+        vector::push_back(&mut list, address3);
+        let group = Group { list: list };
+
+        let groups_ref = &mut borrow_global_mut<Dorm>(MODULE_OWNER).groups;
+        vector::push_back(groups_ref, group);
+    }
+}

--- a/tests/assets/move-projects/multiple-signers/sources/Scripts.move
+++ b/tests/assets/move-projects/multiple-signers/sources/Scripts.move
@@ -1,0 +1,15 @@
+script {
+    use DeveloperBob::Dorm;
+
+    fun init_module(account: signer) {
+        Dorm::init_module(&account);
+    }
+}
+
+script {
+    use DeveloperBob::Dorm;
+
+    fun rent_apartment(acc1: signer, acc2: signer, acc3: signer, months: u8) {
+        Dorm::rent_apartment(&acc1, &acc2, &acc3, months);
+    }
+}


### PR DESCRIPTION
To test script executions with multiple signers, a new move-project is needed. This PR adds such a project.