### PR TITLE
feat: add extrinsic to update stdlib

### DIFF
--- a/src/weights.rs
+++ b/src/weights.rs
@@ -38,6 +38,7 @@ pub trait WeightInfo {
 	fn execute() -> Weight;
 	fn publish_module() -> Weight;
 	fn publish_module_bundle() -> Weight;
+    fn update_stdlib() -> Weight;
 }
 
 /// Weights for pallet_move using the Substrate node and recommended hardware.
@@ -64,6 +65,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 5_336_000 picoseconds.
 		Weight::from_parts(5_700_000, 0)
 	}
+    fn update_stdlib() -> Weight {
+        Weight::from_parts(1_000_000, 0)
+    }
 }
 
 // For backwards compatibility and tests.
@@ -89,4 +93,7 @@ impl WeightInfo for () {
 		// Minimum execution time: 5_336_000 picoseconds.
 		Weight::from_parts(5_700_000, 0)
 	}
+    fn update_stdlib() -> Weight {
+        Weight::from_parts(1_000_000, 0)
+    }
 }

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,0 +1,22 @@
+//! Integration tests related to extrinsic call `update_stdlib`.
+
+mod assets;
+mod mock;
+
+use mock::*;
+
+#[test]
+#[ignore = "to be implemented"]
+fn regular_user_fail() {
+    new_test_ext().execute_with(|| {
+        unimplemented!();
+    });
+}
+
+#[test]
+#[ignore = "to be implemented"]
+fn update_stdlib() {
+    new_test_ext().execute_with(|| {
+        unimplemented!();
+    });
+}


### PR DESCRIPTION
- Add extrinsic call `update_stdlib`, which enables the sudo user to update one standard library
- Add draft for unit tests / to be discussed
- Weights should be updated by benchmarking using the template-node