### PR TITLE
feat: add tests for extrinsic update_stdlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ move-vm-backend-common = { default-features = false, git = "https://github.com/e
 hex = "0.4"
 rand = "0.8"
 lazy_static = "1.4"
+move-stdlib = { git = "https://github.com/eigerco/substrate-move.git", features = ["stdlib-bytecode"] }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0" }

--- a/tests/assets/move-projects/smove-build-all.sh
+++ b/tests/assets/move-projects/smove-build-all.sh
@@ -10,7 +10,11 @@ build_dir=(
     "move-basics"
     "signer-scripts"
 )
-bundle_dir=("using_stdlib_natives")
+bundle_dir=(
+    "testing-move-stdlib"
+    "testing-substrate-stdlib"
+    "using_stdlib_natives"
+)
 
 # Build simple packages
 for i in "${build_dir[@]}"; do

--- a/tests/assets/move-projects/smove-clean-all.sh
+++ b/tests/assets/move-projects/smove-clean-all.sh
@@ -4,22 +4,20 @@
 cd $(dirname $0)
 
 build_dir=(
+    # Modules
     "balance"
     "car-wash-example"
     "get-resource"
     "move-basics"
     "signer-scripts"
+    # Bundles
+    "testing-move-stdlib"
+    "testing-substrate-stdlib"
+    "using_stdlib_natives"
 )
-bundle_dir=("using_stdlib_natives")
 
-# Build simple packages
+# Clean build directories.
 for i in "${build_dir[@]}"; do
-    echo $i
-    rm -rf "$i/build"
-done
-
-# Build bundles
-for i in "${bundle_dir[@]}"; do
     echo $i
     rm -rf "$i/build"
 done

--- a/tests/assets/move-projects/testing-move-stdlib/Move.toml
+++ b/tests/assets/move-projects/testing-move-stdlib/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "testing-move-stdlib"
+version = "0.0.0"
+
+[dependencies]
+
+[addresses]
+std =  "0x1"

--- a/tests/assets/move-projects/testing-move-stdlib/README.md
+++ b/tests/assets/move-projects/testing-move-stdlib/README.md
@@ -1,0 +1,4 @@
+# Notes
+
+- Cloned from the original `move-stdlib` crate.
+- Removed module `signer` because it is the most commonly used module.

--- a/tests/assets/move-projects/testing-move-stdlib/sources/ascii.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/ascii.move
@@ -1,0 +1,148 @@
+/// The `ASCII` module defines basic string and char newtypes in Move that verify
+/// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
+module std::ascii {
+    use std::vector;
+    use std::option::{Self, Option};
+
+    /// An invalid ASCII character was encountered when creating an ASCII string.
+    const EINVALID_ASCII_CHARACTER: u64 = 0x10000;
+
+   /// The `String` struct holds a vector of bytes that all represent
+   /// valid ASCII characters. Note that these ASCII characters may not all
+   /// be printable. To determine if a `String` contains only "printable"
+   /// characters you should use the `all_characters_printable` predicate
+   /// defined in this module.
+   struct String has copy, drop, store {
+       bytes: vector<u8>,
+   }
+   spec String {
+       invariant forall i in 0..len(bytes): is_valid_char(bytes[i]);
+   }
+
+   /// An ASCII character.
+   struct Char has copy, drop, store {
+       byte: u8,
+   }
+   spec Char {
+       invariant is_valid_char(byte);
+   }
+
+    /// Convert a `byte` into a `Char` that is checked to make sure it is valid ASCII.
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), EINVALID_ASCII_CHARACTER);
+        Char { byte }
+    }
+    spec char {
+        aborts_if !is_valid_char(byte) with EINVALID_ASCII_CHARACTER;
+    }
+
+    /// Convert a vector of bytes `bytes` into an `String`. Aborts if
+    /// `bytes` contains non-ASCII characters.
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            option::is_some(&x),
+            EINVALID_ASCII_CHARACTER
+       );
+       option::destroy_some(x)
+    }
+    spec string {
+        aborts_if exists i in 0..len(bytes): !is_valid_char(bytes[i]) with EINVALID_ASCII_CHARACTER;
+    }
+
+    /// Convert a vector of bytes `bytes` into an `String`. Returns
+    /// `Some(<ascii_string>)` if the `bytes` contains all valid ASCII
+    /// characters. Otherwise returns `None`.
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = vector::length(&bytes);
+       let i = 0;
+       while ({
+           spec {
+               invariant i <= len;
+               invariant forall j in 0..i: is_valid_char(bytes[j]);
+           };
+           i < len
+       }) {
+           let possible_byte = *vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return option::none();
+           i = i + 1;
+       };
+       spec {
+           assert i == len;
+           assert forall j in 0..len: is_valid_char(bytes[j]);
+       };
+       option::some(String { bytes })
+    }
+
+    /// Returns `true` if all characters in `string` are printable characters
+    /// Returns `false` otherwise. Not all `String`s are printable strings.
+    public fun all_characters_printable(string: &String): bool {
+       let len = vector::length(&string.bytes);
+       let i = 0;
+       while ({
+           spec {
+               invariant i <= len;
+               invariant forall j in 0..i: is_printable_char(string.bytes[j]);
+           };
+           i < len
+       }) {
+           let byte = *vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       spec {
+           assert i == len;
+           assert forall j in 0..len: is_printable_char(string.bytes[j]);
+       };
+       true
+    }
+    spec all_characters_printable {
+        ensures result ==> (forall j in 0..len(string.bytes): is_printable_char(string.bytes[j]));
+    }
+
+    public fun push_char(string: &mut String, char: Char) {
+        vector::push_back(&mut string.bytes, char.byte);
+    }
+    spec push_char {
+        ensures len(string.bytes) == len(old(string.bytes)) + 1;
+    }
+
+    public fun pop_char(string: &mut String): Char {
+        Char { byte: vector::pop_back(&mut string.bytes) }
+    }
+    spec pop_char {
+        ensures len(string.bytes) == len(old(string.bytes)) - 1;
+    }
+
+    public fun length(string: &String): u64 {
+        vector::length(as_bytes(string))
+    }
+
+    /// Get the inner bytes of the `string` as a reference
+    public fun as_bytes(string: &String): &vector<u8> {
+       &string.bytes
+    }
+
+    /// Unpack the `string` to get its backing bytes
+    public fun into_bytes(string: String): vector<u8> {
+       let String { bytes } = string;
+       bytes
+    }
+
+    /// Unpack the `char` into its underlying byte.
+    public fun byte(char: Char): u8 {
+       let Char { byte } = char;
+       byte
+    }
+
+    /// Returns `true` if `b` is a valid ASCII character. Returns `false` otherwise.
+    public fun is_valid_char(b: u8): bool {
+       b <= 0x7F
+    }
+
+    /// Returns `true` if `byte` is an printable ASCII character. Returns `false` otherwise.
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/bcs.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/bcs.move
@@ -1,0 +1,17 @@
+/// Utility for converting a Move value to its binary representation in BCS (Binary Canonical
+/// Serialization). BCS is the binary encoding for Move resources and other non-module values
+/// published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
+/// details on BCS.
+module std::bcs {
+    /// Return the binary representation of `v` in BCS (Binary Canonical Serialization) format
+    native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
+
+    // ==============================
+    // Module Specification
+    spec module {} // switch to module documentation context
+
+    spec module {
+        /// Native function which is defined in the prover's prelude.
+        native fun serialize<MoveValue>(v: &MoveValue): vector<u8>;
+    }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/bit_vector.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/bit_vector.move
@@ -1,0 +1,161 @@
+module std::bit_vector {
+    use std::vector;
+
+    /// The provided index is out of bounds
+    const EINDEX: u64 = 0x20000;
+    /// An invalid length of bitvector was given
+    const ELENGTH: u64 = 0x20001;
+
+    const WORD_SIZE: u64 = 1;
+    /// The maximum allowed bitvector size
+    const MAX_SIZE: u64 = 1024;
+
+    struct BitVector has copy, drop, store {
+        length: u64,
+        bit_field: vector<bool>,
+    }
+
+    public fun new(length: u64): BitVector {
+        assert!(length > 0, ELENGTH);
+        assert!(length < MAX_SIZE, ELENGTH);
+        let counter = 0;
+        let bit_field = vector::empty();
+        while ({spec {
+            invariant counter <= length;
+            invariant len(bit_field) == counter;
+        };
+            (counter < length)}) {
+            vector::push_back(&mut bit_field, false);
+            counter = counter + 1;
+        };
+        spec {
+            assert counter == length;
+            assert len(bit_field) == length;
+        };
+
+        BitVector {
+            length,
+            bit_field,
+        }
+    }
+    spec new {
+        include NewAbortsIf;
+        ensures result.length == length;
+        ensures len(result.bit_field) == length;
+    }
+    spec schema NewAbortsIf {
+        length: u64;
+        aborts_if length <= 0 with ELENGTH;
+        aborts_if length >= MAX_SIZE with ELENGTH;
+    }
+
+    /// Set the bit at `bit_index` in the `bitvector` regardless of its previous state.
+    public fun set(bitvector: &mut BitVector, bit_index: u64) {
+        assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
+        let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
+        *x = true;
+    }
+    spec set {
+        include SetAbortsIf;
+        ensures bitvector.bit_field[bit_index];
+    }
+    spec schema SetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with EINDEX;
+    }
+
+    /// Unset the bit at `bit_index` in the `bitvector` regardless of its previous state.
+    public fun unset(bitvector: &mut BitVector, bit_index: u64) {
+        assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
+        let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
+        *x = false;
+    }
+    spec unset {
+        include UnsetAbortsIf;
+        ensures !bitvector.bit_field[bit_index];
+    }
+    spec schema UnsetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with EINDEX;
+    }
+
+    /// Shift the `bitvector` left by `amount`. If `amount` is greater than the
+    /// bitvector's length the bitvector will be zeroed out.
+    public fun shift_left(bitvector: &mut BitVector, amount: u64) {
+        if (amount >= bitvector.length) {
+           let len = vector::length(&bitvector.bit_field);
+           let i = 0;
+           while (i < len) {
+               let elem = vector::borrow_mut(&mut bitvector.bit_field, i);
+               *elem = false;
+               i = i + 1;
+           };
+        } else {
+            let i = amount;
+
+            while (i < bitvector.length) {
+                if (is_index_set(bitvector, i)) set(bitvector, i - amount)
+                else unset(bitvector, i - amount);
+                i = i + 1;
+            };
+
+            i = bitvector.length - amount;
+
+            while (i < bitvector.length) {
+                unset(bitvector, i);
+                i = i + 1;
+            };
+        }
+    }
+
+    /// Return the value of the bit at `bit_index` in the `bitvector`. `true`
+    /// represents "1" and `false` represents a 0
+    public fun is_index_set(bitvector: &BitVector, bit_index: u64): bool {
+        assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
+        *vector::borrow(&bitvector.bit_field, bit_index)
+    }
+    spec is_index_set {
+        include IsIndexSetAbortsIf;
+        ensures result == bitvector.bit_field[bit_index];
+    }
+    spec schema IsIndexSetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with EINDEX;
+    }
+    spec fun spec_is_index_set(bitvector: BitVector, bit_index: u64): bool {
+        if (bit_index >= length(bitvector)) {
+            false
+        } else {
+            bitvector.bit_field[bit_index]
+        }
+    }
+
+    /// Return the length (number of usable bits) of this bitvector
+    public fun length(bitvector: &BitVector): u64 {
+        vector::length(&bitvector.bit_field)
+    }
+
+    /// Returns the length of the longest sequence of set bits starting at (and
+    /// including) `start_index` in the `bitvector`. If there is no such
+    /// sequence, then `0` is returned.
+    public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
+        assert!(start_index < bitvector.length, EINDEX);
+        let index = start_index;
+
+        // Find the greatest index in the vector such that all indices less than it are set.
+        while (index < bitvector.length) {
+            if (!is_index_set(bitvector, index)) break;
+            index = index + 1;
+        };
+
+        index - start_index
+    }
+
+    #[test_only]
+    public fun word_size(): u64 {
+        WORD_SIZE
+    }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/error.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/error.move
@@ -1,0 +1,81 @@
+/// This module defines a set of canonical error codes which are optional to use by applications for the
+/// `abort` and `assert!` features.
+///
+/// Canonical error codes use the 3 lowest bytes of the u64 abort code range (the upper 5 bytes are free for other use).
+/// Of those, the highest byte represents the *error category* and the lower two bytes the *error reason*.
+/// Given an error category `0x1` and a reason `0x3`, a canonical abort code looks as `0x10003`.
+///
+/// A module can use a canonical code with a constant declaration of the following form:
+///
+/// ```
+/// ///  An invalid ASCII character was encountered when creating a string.
+/// const EINVALID_CHARACTER: u64 = 0x010003;
+/// ```
+///
+/// This code is both valid in the worlds with and without canonical errors. It can be used as a plain module local
+/// error reason understand by the existing error map tooling, or as a canonical code.
+///
+/// The actual canonical categories have been adopted from Google's canonical error codes, which in turn are derived
+/// from Unix error codes [see here](https://cloud.google.com/apis/design/errors#handling_errors). Each code has an
+/// associated HTTP error code which can be used in REST apis. The mapping from error code to http code is not 1:1;
+/// error codes here are a bit richer than HTTP codes.
+module std::error {
+
+  /// Caller specified an invalid argument (http: 400)
+  const INVALID_ARGUMENT: u64 = 0x1;
+
+  /// An input or result of a computation is out of range (http: 400)
+  const OUT_OF_RANGE: u64 = 0x2;
+
+  /// The system is not in a state where the operation can be performed (http: 400)
+  const INVALID_STATE: u64 = 0x3;
+
+  /// Request not authenticated due to missing, invalid, or expired auth token (http: 401)
+  const UNAUTHENTICATED: u64 = 0x4;
+
+  /// client does not have sufficient permission (http: 403)
+  const PERMISSION_DENIED: u64 = 0x5;
+
+  /// A specified resource is not found (http: 404)
+  const NOT_FOUND: u64 = 0x6;
+
+  /// Concurrency conflict, such as read-modify-write conflict (http: 409)
+  const ABORTED: u64 = 0x7;
+
+  /// The resource that a client tried to create already exists (http: 409)
+  const ALREADY_EXISTS: u64 = 0x8;
+
+  /// Out of gas or other forms of quota (http: 429)
+  const RESOURCE_EXHAUSTED: u64 = 0x9;
+
+  /// Request cancelled by the client (http: 499)
+  const CANCELLED: u64 = 0xA;
+
+  /// Internal error (http: 500)
+  const INTERNAL: u64 = 0xB;
+
+  /// Feature not implemented (http: 501)
+  const NOT_IMPLEMENTED: u64 = 0xC;
+
+  /// The service is currently unavailable. Indicates that a retry could solve the issue (http: 503)
+  const UNAVAILABLE: u64 = 0xD;
+
+  /// Construct a canonical error code from a category and a reason.
+  public fun canonical(category: u64, reason: u64): u64 {
+    (category << 16) + reason
+  }
+
+  /// Functions to construct a canonical error code of the given category.
+  public fun invalid_argument(r: u64): u64 {  canonical(INVALID_ARGUMENT, r) }
+  public fun out_of_range(r: u64): u64 {  canonical(OUT_OF_RANGE, r) }
+  public fun invalid_state(r: u64): u64 {  canonical(INVALID_STATE, r) }
+  public fun unauthenticated(r: u64): u64 { canonical(UNAUTHENTICATED, r) }
+  public fun permission_denied(r: u64): u64 { canonical(PERMISSION_DENIED, r) }
+  public fun not_found(r: u64): u64 { canonical(NOT_FOUND, r) }
+  public fun aborted(r: u64): u64 { canonical(ABORTED, r) }
+  public fun already_exists(r: u64): u64 { canonical(ALREADY_EXISTS, r) }
+  public fun resource_exhausted(r: u64): u64 {  canonical(RESOURCE_EXHAUSTED, r) }
+  public fun internal(r: u64): u64 {  canonical(INTERNAL, r) }
+  public fun not_implemented(r: u64): u64 {  canonical(NOT_IMPLEMENTED, r) }
+  public fun unavailable(r: u64): u64 { canonical(UNAVAILABLE, r) }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/fixed_point32.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/fixed_point32.move
@@ -1,0 +1,294 @@
+/// Defines a fixed-point numeric type with a 32-bit integer part and
+/// a 32-bit fractional part.
+
+module std::fixed_point32 {
+
+    /// Define a fixed-point numeric type with 32 fractional bits.
+    /// This is just a u64 integer but it is wrapped in a struct to
+    /// make a unique type. This is a binary representation, so decimal
+    /// values may not be exactly representable, but it provides more
+    /// than 9 decimal digits of precision both before and after the
+    /// decimal point (18 digits total). For comparison, double precision
+    /// floating-point has less than 16 decimal digits of precision, so
+    /// be careful about using floating-point to convert these values to
+    /// decimal.
+    struct FixedPoint32 has copy, drop, store { value: u64 }
+
+    ///> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
+    const MAX_U64: u128 = 18446744073709551615;
+
+    /// The denominator provided was zero
+    const EDENOMINATOR: u64 = 0x10001;
+    /// The quotient value would be too large to be held in a `u64`
+    const EDIVISION: u64 = 0x20002;
+    /// The multiplied value would be too large to be held in a `u64`
+    const EMULTIPLICATION: u64 = 0x20003;
+    /// A division by zero was encountered
+    const EDIVISION_BY_ZERO: u64 = 0x10004;
+    /// The computed ratio when converting to a `FixedPoint32` would be unrepresentable
+    const ERATIO_OUT_OF_RANGE: u64 = 0x20005;
+
+    /// Multiply a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the product. This will abort if the product
+    /// overflows.
+    public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64 {
+        // The product of two 64 bit values has 128 bits, so perform the
+        // multiplication with u128 types and keep the full 128 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (val as u128) * (multiplier.value as u128);
+        // The unscaled product has 32 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 32;
+        // Check whether the value is too large.
+        assert!(product <= MAX_U64, EMULTIPLICATION);
+        (product as u64)
+    }
+    spec multiply_u64 {
+        pragma opaque;
+        include MultiplyAbortsIf;
+        ensures result == spec_multiply_u64(val, multiplier);
+    }
+    spec schema MultiplyAbortsIf {
+        val: num;
+        multiplier: FixedPoint32;
+        aborts_if spec_multiply_u64(val, multiplier) > MAX_U64 with EMULTIPLICATION;
+    }
+    spec fun spec_multiply_u64(val: num, multiplier: FixedPoint32): num {
+        (val * multiplier.value) >> 32
+    }
+
+    /// Divide a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the quotient. This will abort if the divisor
+    /// is zero or if the quotient overflows.
+    public fun divide_u64(val: u64, divisor: FixedPoint32): u64 {
+        // Check for division by zero.
+        assert!(divisor.value != 0, EDIVISION_BY_ZERO);
+        // First convert to 128 bits and then shift left to
+        // add 32 fractional zero bits to the dividend.
+        let scaled_value = (val as u128) << 32;
+        let quotient = scaled_value / (divisor.value as u128);
+        // Check whether the value is too large.
+        assert!(quotient <= MAX_U64, EDIVISION);
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (quotient as u64)
+    }
+    spec divide_u64 {
+        pragma opaque;
+        include DivideAbortsIf;
+        ensures result == spec_divide_u64(val, divisor);
+    }
+    spec schema DivideAbortsIf {
+        val: num;
+        divisor: FixedPoint32;
+        aborts_if divisor.value == 0 with EDIVISION_BY_ZERO;
+        aborts_if spec_divide_u64(val, divisor) > MAX_U64 with EDIVISION;
+    }
+    spec fun spec_divide_u64(val: num, divisor: FixedPoint32): num {
+        (val << 32) / divisor.value
+    }
+
+    /// Create a fixed-point value from a rational number specified by its
+    /// numerator and denominator. Calling this function should be preferred
+    /// for using `Self::create_from_raw_value` which is also available.
+    /// This will abort if the denominator is zero. It will also
+    /// abort if the numerator is nonzero and the ratio is not in the range
+    /// 2^-32 .. 2^32-1. When specifying decimal fractions, be careful about
+    /// rounding errors: if you round to display N digits after the decimal
+    /// point, you can use a denominator of 10^N to avoid numbers where the
+    /// very small imprecision in the binary representation could change the
+    /// rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+    public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32 {
+        // If the denominator is zero, this will abort.
+        // Scale the numerator to have 64 fractional bits and the denominator
+        // to have 32 fractional bits, so that the quotient will have 32
+        // fractional bits.
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        assert!(scaled_denominator != 0, EDENOMINATOR);
+        let quotient = scaled_numerator / scaled_denominator;
+        assert!(quotient != 0 || numerator == 0, ERATIO_OUT_OF_RANGE);
+        // Return the quotient as a fixed-point number. We first need to check whether the cast
+        // can succeed.
+        assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        FixedPoint32 { value: (quotient as u64) }
+    }
+    spec create_from_rational {
+        pragma opaque;
+        include CreateFromRationalAbortsIf;
+        ensures result == spec_create_from_rational(numerator, denominator);
+    }
+    spec schema CreateFromRationalAbortsIf {
+        numerator: u64;
+        denominator: u64;
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        let quotient = scaled_numerator / scaled_denominator;
+        aborts_if scaled_denominator == 0 with EDENOMINATOR;
+        aborts_if quotient == 0 && scaled_numerator != 0 with ERATIO_OUT_OF_RANGE;
+        aborts_if quotient > MAX_U64 with ERATIO_OUT_OF_RANGE;
+    }
+    spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint32 {
+        FixedPoint32{value: (numerator << 64) / (denominator << 32)}
+    }
+
+    /// Create a fixedpoint value from a raw value.
+    public fun create_from_raw_value(value: u64): FixedPoint32 {
+        FixedPoint32 { value }
+    }
+    spec create_from_raw_value {
+        pragma opaque;
+        aborts_if false;
+        ensures result.value == value;
+    }
+
+    /// Accessor for the raw u64 value. Other less common operations, such as
+    /// adding or subtracting FixedPoint32 values, can be done using the raw
+    /// values directly.
+    public fun get_raw_value(num: FixedPoint32): u64 {
+        num.value
+    }
+
+    /// Returns true if the ratio is zero.
+    public fun is_zero(num: FixedPoint32): bool {
+        num.value == 0
+    }
+
+    /// Returns the smaller of the two FixedPoint32 numbers.
+    public fun min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value < num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+    spec min {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_min(num1, num2);
+    }
+    spec fun spec_min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value < num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+
+    /// Returns the larger of the two FixedPoint32 numbers.
+    public fun max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value > num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+    spec max {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_max(num1, num2);
+    }
+    spec fun spec_max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
+        if (num1.value > num2.value) {
+            num1
+        } else {
+            num2
+        }
+    }
+
+    /// Create a fixedpoint value from a u64 value.
+    public fun create_from_u64(val: u64): FixedPoint32 {
+        let value = (val as u128) << 32;
+        assert!(value <= MAX_U64, ERATIO_OUT_OF_RANGE);
+        FixedPoint32{value: (value as u64)}
+    }
+    spec create_from_u64 {
+        pragma opaque;
+        include CreateFromU64AbortsIf;
+        ensures result == spec_create_from_u64(val);
+    }
+    spec schema CreateFromU64AbortsIf {
+        val: num;
+        let scaled_value = (val as u128) << 32;
+        aborts_if scaled_value > MAX_U64;
+    }
+    spec fun spec_create_from_u64(val: num): FixedPoint32 {
+        FixedPoint32 {value: val << 32}
+    }
+
+    /// Returns the largest integer less than or equal to a given number.
+    public fun floor(num: FixedPoint32): u64 {
+        num.value >> 32
+    }
+    spec floor {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_floor(num);
+    }
+    spec fun spec_floor(val: FixedPoint32): u64 {
+        let fractional = val.value % (1 << 32);
+        if (fractional == 0) {
+            val.value >> 32
+        } else {
+            (val.value - fractional) >> 32
+        }
+    }
+
+    /// Rounds up the given FixedPoint32 to the next largest integer.
+    public fun ceil(num: FixedPoint32): u64 {
+        let floored_num = floor(num) << 32;
+        if (num.value == floored_num) {
+            return floored_num >> 32
+        };
+        let val = ((floored_num as u128) + (1 << 32));
+        (val >> 32 as u64)
+    }
+    spec ceil {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_ceil(num);
+    }
+    spec fun spec_ceil(val: FixedPoint32): u64 {
+        let fractional = val.value % (1 << 32);
+        let one = 1 << 32;
+        if (fractional == 0) {
+            val.value >> 32
+        } else {
+            (val.value - fractional + one) >> 32
+        }
+    }
+
+    /// Returns the value of a FixedPoint32 to the nearest integer.
+    public fun round(num: FixedPoint32): u64 {
+        let floored_num = floor(num) << 32;
+        let boundary = floored_num + ((1 << 32) / 2);
+        if (num.value < boundary) {
+            floored_num >> 32
+        } else {
+            ceil(num)
+        }
+    }
+    spec round {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_round(num);
+    }
+    spec fun spec_round(val: FixedPoint32): u64 {
+        let fractional = val.value % (1 << 32);
+        let boundary = (1 << 32) / 2;
+        let one = 1 << 32;
+        if (fractional < boundary) {
+            (val.value - fractional) >> 32
+        } else {
+            (val.value - fractional + one) >> 32
+        }
+    }
+
+    // **************** SPECIFICATIONS ****************
+
+    spec module {} // switch documentation context to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/hash.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/hash.move
@@ -1,0 +1,8 @@
+/// Module which defines SHA hashes for byte vectors.
+///
+/// The functions in this module are natively declared both in the Move runtime
+/// as in the Move prover's prelude.
+module std::hash {
+    native public fun sha2_256(data: vector<u8>): vector<u8>;
+    native public fun sha3_256(data: vector<u8>): vector<u8>;
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/option.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/option.move
@@ -1,0 +1,260 @@
+/// This module defines the Option type and its methods to represent and handle an optional value.
+module std::option {
+    use std::vector;
+
+    /// Abstraction of a value that may or may not be present. Implemented with a vector of size
+    /// zero or one because Move bytecode does not have ADTs.
+    struct Option<Element> has copy, drop, store {
+        vec: vector<Element>
+    }
+    spec Option {
+        /// The size of vector is always less than equal to 1
+        /// because it's 0 for "none" or 1 for "some".
+        invariant len(vec) <= 1;
+    }
+
+    /// The `Option` is in an invalid state for the operation attempted.
+    /// The `Option` is `Some` while it should be `None`.
+    const EOPTION_IS_SET: u64 = 0x40000;
+    /// The `Option` is in an invalid state for the operation attempted.
+    /// The `Option` is `None` while it should be `Some`.
+    const EOPTION_NOT_SET: u64 = 0x40001;
+
+    /// Return an empty `Option`
+    public fun none<Element>(): Option<Element> {
+        Option { vec: vector::empty() }
+    }
+    spec none {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_none<Element>();
+    }
+    spec fun spec_none<Element>(): Option<Element> {
+        Option{ vec: vec() }
+    }
+
+    /// Return an `Option` containing `e`
+    public fun some<Element>(e: Element): Option<Element> {
+        Option { vec: vector::singleton(e) }
+    }
+    spec some {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_some(e);
+    }
+    spec fun spec_some<Element>(e: Element): Option<Element> {
+        Option{ vec: vec(e) }
+    }
+
+    /// Return true if `t` does not hold a value
+    public fun is_none<Element>(t: &Option<Element>): bool {
+        vector::is_empty(&t.vec)
+    }
+    spec is_none {
+        pragma opaque;
+        aborts_if false;
+        ensures result == is_none(t);
+    }
+
+    /// Return true if `t` holds a value
+    public fun is_some<Element>(t: &Option<Element>): bool {
+        !vector::is_empty(&t.vec)
+    }
+    spec is_some {
+        pragma opaque;
+        aborts_if false;
+        ensures result == is_some(t);
+    }
+
+    /// Return true if the value in `t` is equal to `e_ref`
+    /// Always returns `false` if `t` does not hold a value
+    public fun contains<Element>(t: &Option<Element>, e_ref: &Element): bool {
+        vector::contains(&t.vec, e_ref)
+    }
+    spec contains {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_contains(t, e_ref);
+    }
+    spec fun spec_contains<Element>(t: Option<Element>, e: Element): bool {
+        is_some(t) && borrow(t) == e
+    }
+
+    /// Return an immutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun borrow<Element>(t: &Option<Element>): &Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        vector::borrow(&t.vec, 0)
+    }
+    spec borrow {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Return a reference to the value inside `t` if it holds one
+    /// Return `default_ref` if `t` does not hold a value
+    public fun borrow_with_default<Element>(t: &Option<Element>, default_ref: &Element): &Element {
+        let vec_ref = &t.vec;
+        if (vector::is_empty(vec_ref)) default_ref
+        else vector::borrow(vec_ref, 0)
+    }
+    spec borrow_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default_ref);
+    }
+
+    /// Return the value inside `t` if it holds one
+    /// Return `default` if `t` does not hold a value
+    public fun get_with_default<Element: copy + drop>(
+        t: &Option<Element>,
+        default: Element,
+    ): Element {
+        let vec_ref = &t.vec;
+        if (vector::is_empty(vec_ref)) default
+        else *vector::borrow(vec_ref, 0)
+    }
+    spec get_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default);
+    }
+
+    /// Convert the none option `t` to a some option by adding `e`.
+    /// Aborts if `t` already holds a value
+    public fun fill<Element>(t: &mut Option<Element>, e: Element) {
+        let vec_ref = &mut t.vec;
+        if (vector::is_empty(vec_ref)) vector::push_back(vec_ref, e)
+        else abort EOPTION_IS_SET
+    }
+    spec fill {
+        pragma opaque;
+        aborts_if is_some(t) with EOPTION_IS_SET;
+        ensures is_some(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun extract<Element>(t: &mut Option<Element>): Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        vector::pop_back(&mut t.vec)
+    }
+    spec extract {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(old(t));
+        ensures is_none(t);
+    }
+
+    /// Return a mutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        vector::borrow_mut(&mut t.vec, 0)
+    }
+    spec borrow_mut {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+        ensures t == old(t);
+    }
+
+    /// Swap the old value inside `t` with `e` and return the old value
+    /// Aborts if `t` does not hold a value
+    public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
+        assert!(is_some(t), EOPTION_NOT_SET);
+        let vec_ref = &mut t.vec;
+        let old_value = vector::pop_back(vec_ref);
+        vector::push_back(vec_ref, e);
+        old_value
+    }
+    spec swap {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(old(t));
+        ensures is_some(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Swap the old value inside `t` with `e` and return the old value;
+    /// or if there is no old value, fill it with `e`.
+    /// Different from swap(), swap_or_fill() allows for `t` not holding a value.
+    public fun swap_or_fill<Element>(t: &mut Option<Element>, e: Element): Option<Element> {
+        let vec_ref = &mut t.vec;
+        let old_value = if (vector::is_empty(vec_ref)) none()
+            else some(vector::pop_back(vec_ref));
+        vector::push_back(vec_ref, e);
+        old_value
+    }
+    spec swap_or_fill {
+        pragma opaque;
+        ensures result == old(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
+    public fun destroy_with_default<Element: drop>(t: Option<Element>, default: Element): Element {
+        let Option { vec } = t;
+        if (vector::is_empty(&mut vec)) default
+        else vector::pop_back(&mut vec)
+    }
+    spec destroy_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default);
+    }
+
+    /// Unpack `t` and return its contents
+    /// Aborts if `t` does not hold a value
+    public fun destroy_some<Element>(t: Option<Element>): Element {
+        assert!(is_some(&t), EOPTION_NOT_SET);
+        let Option { vec } = t;
+        let elem = vector::pop_back(&mut vec);
+        vector::destroy_empty(vec);
+        elem
+    }
+    spec destroy_some {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Unpack `t`
+    /// Aborts if `t` holds a value
+    public fun destroy_none<Element>(t: Option<Element>) {
+        assert!(is_none(&t), EOPTION_IS_SET);
+        let Option { vec } = t;
+        vector::destroy_empty(vec)
+    }
+    spec destroy_none {
+        pragma opaque;
+        aborts_if is_some(t) with EOPTION_IS_SET;
+    }
+
+    /// Convert `t` into a vector of length 1 if it is `Some`,
+    /// and an empty vector otherwise
+    public fun to_vec<Element>(t: Option<Element>): vector<Element> {
+        let Option { vec } = t;
+        vec
+    }
+    spec to_vec {
+        pragma opaque;
+        aborts_if false;
+        ensures result == t.vec;
+    }
+
+    spec module {} // switch documentation context back to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+
+    /// # Helper Schema
+
+    spec schema AbortsIfNone<Element> {
+        t: Option<Element>;
+        aborts_if is_none(t) with EOPTION_NOT_SET;
+    }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/string.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/string.move
@@ -1,0 +1,94 @@
+/// The `string` module defines the `String` type which represents UTF8 encoded strings.
+module std::string {
+    use std::vector;
+    use std::option::{Self, Option};
+
+    /// An invalid UTF8 encoding.
+    const EINVALID_UTF8: u64 = 1;
+
+    /// Index out of range.
+    const EINVALID_INDEX: u64 = 2;
+
+    /// A `String` holds a sequence of bytes which is guaranteed to be in utf8 format.
+    struct String has copy, drop, store {
+        bytes: vector<u8>,
+    }
+
+    /// Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
+    public fun utf8(bytes: vector<u8>): String {
+        assert!(internal_check_utf8(&bytes), EINVALID_UTF8);
+        String { bytes }
+    }
+
+    /// Tries to create a new string from a sequence of bytes.
+    public fun try_utf8(bytes: vector<u8>): Option<String> {
+        if (internal_check_utf8(&bytes)) {
+            option::some(String { bytes })
+        } else {
+            option::none()
+        }
+    }
+
+    /// Returns a reference to the underlying byte vector.
+    public fun bytes(s: &String): &vector<u8> {
+        &s.bytes
+    }
+
+    /// Checks whether this string is empty.
+    public fun is_empty(s: &String): bool {
+        vector::is_empty(&s.bytes)
+    }
+
+    /// Returns the length of this string, in bytes.
+    public fun length(s: &String): u64 {
+        vector::length(&s.bytes)
+    }
+
+    /// Appends a string.
+    public fun append(s: &mut String, r: String) {
+        vector::append(&mut s.bytes, r.bytes)
+    }
+
+    /// Appends bytes which must be in valid utf8 format.
+    public fun append_utf8(s: &mut String, bytes: vector<u8>) {
+        append(s, utf8(bytes))
+    }
+
+    /// Insert the other string at the byte index in given string. The index must be at a valid utf8 char
+    /// boundary.
+    public fun insert(s: &mut String, at: u64, o: String) {
+        let bytes = &s.bytes;
+        assert!(at <= vector::length(bytes) && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
+        let l = length(s);
+        let front = sub_string(s, 0, at);
+        let end = sub_string(s, at, l);
+        append(&mut front, o);
+        append(&mut front, end);
+        *s = front;
+    }
+
+    /// Returns a sub-string using the given byte indices, where `i` is the first byte position and `j` is the start
+    /// of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
+    /// guaranteeing that the result is valid utf8.
+    public fun sub_string(s: &String, i: u64, j: u64): String {
+        let bytes = &s.bytes;
+        let l = vector::length(bytes);
+        assert!(
+            j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
+            EINVALID_INDEX
+        );
+        String { bytes: internal_sub_string(bytes, i, j) }
+    }
+
+    /// Computes the index of the first occurrence of a string. Returns `length(s)` if no occurrence found.
+    public fun index_of(s: &String, r: &String): u64 {
+        internal_index_of(&s.bytes, &r.bytes)
+    }
+
+
+    // Native API
+    native fun internal_check_utf8(v: &vector<u8>): bool;
+    native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;
+    native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
+    native fun internal_index_of(v: &vector<u8>, r: &vector<u8>): u64;
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/type_name.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/type_name.move
@@ -1,0 +1,28 @@
+/// Functionality for converting Move types into values. Use with care!
+module std::type_name {
+    use std::ascii::String;
+
+    struct TypeName has copy, drop, store {
+        /// String representation of the type. All types are represented
+        /// using their source syntax:
+        /// "u8", "u64", "u128", "bool", "address", "vector", "signer" for ground types.
+        /// Struct types are represented as fully qualified type names; e.g.
+        /// `00000000000000000000000000000001::string::String` or
+        /// `0000000000000000000000000000000a::module_name1::type_name1<0000000000000000000000000000000a::module_name2::type_name2<u64>>`
+        /// Addresses are hex-encoded lowercase values of length ADDRESS_LENGTH (16, 20, or 32 depending on the Move platform)
+        name: String
+    }
+
+    /// Return a value representation of the type `T`.
+    public native fun get<T>(): TypeName;
+
+    /// Get the String representation of `self`
+    public fun borrow_string(self: &TypeName): &String {
+        &self.name
+    }
+
+    /// Convert `self` into its inner String
+    public fun into_string(self: TypeName): String {
+        self.name
+    }
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/unit_test.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/unit_test.move
@@ -1,0 +1,12 @@
+#[test_only]
+/// Module providing testing functionality. Only included for tests.
+module std::unit_test {
+    /// Return a `num_signers` number of unique signer values. No ordering or
+    /// starting value guarantees are made, only that the order and values of
+    /// the signers in the returned vector is deterministic.
+    ///
+    /// This function is also used to poison modules compiled in `test` mode.
+    /// This will cause a linking failure if an attempt is made to publish a
+    /// test module in a VM that isn't in unit test mode.
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+}

--- a/tests/assets/move-projects/testing-move-stdlib/sources/vector.move
+++ b/tests/assets/move-projects/testing-move-stdlib/sources/vector.move
@@ -1,0 +1,217 @@
+/// A variable-sized container that can hold any type. Indexing is 0-based, and
+/// vectors are growable. This module has many native functions.
+/// Verification of modules that use this one uses model functions that are implemented
+/// directly in Boogie. The specification language has built-in functions operations such
+/// as `singleton_vector`. There are some helper functions defined here for specifications in other
+/// modules as well.
+///
+/// >Note: We did not verify most of the
+/// Move functions here because many have loops, requiring loop invariants to prove, and
+/// the return on investment didn't seem worth it for these simple functions.
+module std::vector {
+
+    /// The index into the vector is out of bounds
+    const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
+
+    #[bytecode_instruction]
+    /// Create an empty vector.
+    native public fun empty<Element>(): vector<Element>;
+
+    #[bytecode_instruction]
+    /// Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    #[bytecode_instruction]
+    /// Acquire an immutable reference to the `i`th element of the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    #[bytecode_instruction]
+    /// Add element `e` to the end of the vector `v`.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    #[bytecode_instruction]
+    /// Return a mutable reference to the `i`th element in the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+
+    #[bytecode_instruction]
+    /// Pop an element from the end of vector `v`.
+    /// Aborts if `v` is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    #[bytecode_instruction]
+    /// Destroy the vector `v`.
+    /// Aborts if `v` is not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    #[bytecode_instruction]
+    /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
+    /// Aborts if `i` or `j` is out of bounds.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    /// Return an vector of size one containing element `e`.
+    public fun singleton<Element>(e: Element): vector<Element> {
+        let v = empty();
+        push_back(&mut v, e);
+        v
+    }
+    spec singleton {
+        // TODO: when using opaque here, we get verification errors.
+        // pragma opaque;
+        aborts_if false;
+        ensures result == vec(e);
+    }
+
+    /// Reverses the order of the elements in the vector `v` in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+    spec reverse {
+        pragma intrinsic = true;
+    }
+
+
+    /// Pushes all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+    spec append {
+        pragma intrinsic = true;
+    }
+    spec is_empty {
+        pragma intrinsic = true;
+    }
+
+
+    /// Return `true` if the vector `v` has no elements and `false` otherwise.
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    /// Return true if `e` is in the vector `v`.
+    /// Otherwise, returns false.
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+    spec contains {
+        pragma intrinsic = true;
+    }
+
+    /// Return `(true, i)` if `e` is in the vector `v` at index `i`.
+    /// Otherwise, returns `(false, 0)`.
+    public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64) {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return (true, i);
+            i = i + 1;
+        };
+        (false, 0)
+    }
+    spec index_of {
+        pragma intrinsic = true;
+    }
+
+    /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+    spec remove {
+        pragma intrinsic = true;
+    }
+
+    /// Insert `e` at position `i` in the vector `v`.
+    /// If `i` is in bounds, this shifts the old `v[i]` and all subsequent elements to the right.
+    /// If `i == length(v)`, this adds `e` to the end of the vector.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i > length(v)`
+    public fun insert<Element>(v: &mut vector<Element>, e: Element, i: u64) {
+        let len = length(v);
+        // i too big abort
+        if (i > len) abort EINDEX_OUT_OF_BOUNDS;
+
+        push_back(v, e);
+        while (i < len) {
+            swap(v, i, len);
+            i = i + 1
+        }
+    }
+    spec insert {
+        pragma intrinsic = true;
+    }
+
+    /// Swap the `i`th element of the vector `v` with the last element and then pop the vector.
+    /// This is O(1), but does not preserve ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        assert!(!is_empty(v), EINDEX_OUT_OF_BOUNDS);
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+    spec swap_remove {
+        pragma intrinsic = true;
+    }
+
+    // =================================================================
+    // Module Specification
+
+    spec module {} // Switch to module documentation context
+
+    /// # Helper Functions
+
+    spec module {
+        /// Check if `v1` is equal to the result of adding `e` at the end of `v2`
+        fun eq_push_back<Element>(v1: vector<Element>, v2: vector<Element>, e: Element): bool {
+            len(v1) == len(v2) + 1 &&
+            v1[len(v1)-1] == e &&
+            v1[0..len(v1)-1] == v2[0..len(v2)]
+        }
+
+        /// Check if `v` is equal to the result of concatenating `v1` and `v2`
+        fun eq_append<Element>(v: vector<Element>, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v) == len(v1) + len(v2) &&
+            v[0..len(v1)] == v1 &&
+            v[len(v1)..len(v)] == v2
+        }
+
+        /// Check `v1` is equal to the result of removing the first element of `v2`
+        fun eq_pop_front<Element>(v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1 == v2[1..len(v2)]
+        }
+
+        /// Check that `v1` is equal to the result of removing the element at index `i` from `v2`.
+        fun eq_remove_elem_at_index<Element>(i: u64, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1[0..i] == v2[0..i] &&
+            v1[i..len(v1)] == v2[i + 1..len(v2)]
+        }
+    }
+}

--- a/tests/assets/move-projects/testing-substrate-stdlib/Move.toml
+++ b/tests/assets/move-projects/testing-substrate-stdlib/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "testing-substrate-stdlib"
+version = "0.0.0"
+
+[dependencies]
+
+[addresses]
+substrate =  "0x1"

--- a/tests/assets/move-projects/testing-substrate-stdlib/README.md
+++ b/tests/assets/move-projects/testing-substrate-stdlib/README.md
@@ -1,0 +1,5 @@
+# Notes
+
+- Cloned from the original `substrate-stdlib` crate.
+- The same interface was kept, but functionless local implementations replaced native methods.
+  Have a look at the [modified balance module](sources/balance.move).

--- a/tests/assets/move-projects/testing-substrate-stdlib/sources/balance.move
+++ b/tests/assets/move-projects/testing-substrate-stdlib/sources/balance.move
@@ -1,0 +1,22 @@
+/// A balance module provides access to external balance-handling functionality,
+/// which is contained within the Substrate layer in our case.
+///
+/// If a script wants to execute a transfer, a transaction which contains the script must receive two parameters:
+/// - signer - A proof that the account has signed the transaction.
+/// - cheque_amount - How many funds is the signer account allowing a script to transfer from that account.
+///                   The provided amount remains in the signer account if the script doesn't perform any transfer.
+module substrate::balance {
+    /// Perform a transfer.
+    ///
+    /// Returns true in case the transfer executed successfully.
+    /// An error indicates insufficient funds in the provided cheque.
+    public fun transfer(_src: &signer, _dst: address, _cheque_amount: u128): bool { false }
+
+    /// Get the current cheque amount for the address.
+    ///
+    /// The cheque amount is the amount the address is allowed to transfer within the current executing context.
+    public fun cheque_amount(_account: address): u128 { 0 }
+
+    /// Get the total balance for the address.
+    public fun total_amount(_account: address): u128 { 0 }
+}

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -3,20 +3,97 @@
 mod assets;
 mod mock;
 
+use frame_support::{assert_err, assert_ok, pallet_prelude::DispatchError};
 use mock::*;
+use move_stdlib::{move_stdlib_bundle, substrate_stdlib_bundle};
+use move_vm_backend::types::MAX_GAS_AMOUNT;
+use move_vm_backend_common::types::ScriptTransaction;
 
-#[test]
-#[ignore = "to be implemented"]
-fn regular_user_fail() {
-    new_test_ext().execute_with(|| {
-        unimplemented!();
-    });
+fn mock_move_stdlib() -> Vec<u8> {
+    assets::read_bundle_from_project("testing-move-stdlib", "testing-move-stdlib")
+}
+
+fn mock_substrate_stdlib() -> Vec<u8> {
+    assets::read_bundle_from_project("testing-substrate-stdlib", "testing-substrate-stdlib")
 }
 
 #[test]
-#[ignore = "to be implemented"]
+fn regular_user_fail() {
+    let move_stdlib = move_stdlib_bundle().to_vec();
+    let sub_stdlib = substrate_stdlib_bundle().to_vec();
+
+    ExtBuilder::default()
+        .with_move_stdlib(Some(mock_move_stdlib()))
+        .with_substrate_stdlib(Some(mock_substrate_stdlib()))
+        .build()
+        .execute_with(|| {
+            assert_err!(
+                MoveModule::update_stdlib(
+                    RuntimeOrigin::signed(CAFE_ADDR_NATIVE.clone()),
+                    move_stdlib,
+                ),
+                DispatchError::BadOrigin,
+            );
+            assert_err!(
+                MoveModule::update_stdlib(
+                    RuntimeOrigin::signed(CAFE_ADDR_NATIVE.clone()),
+                    sub_stdlib,
+                ),
+                DispatchError::BadOrigin,
+            );
+        });
+}
+
+#[test]
 fn update_stdlib() {
-    new_test_ext().execute_with(|| {
-        unimplemented!();
-    });
+    let (bob_addr_32, bob_addr_mv) = addrs_from_ss58(BOB_ADDR).unwrap();
+    let move_stdlib = move_stdlib_bundle().to_vec();
+    let sub_stdlib = substrate_stdlib_bundle().to_vec();
+
+    ExtBuilder::default()
+        .with_move_stdlib(Some(mock_move_stdlib()))
+        .with_substrate_stdlib(Some(mock_substrate_stdlib()))
+        .build()
+        .execute_with(|| {
+            let car_wash_module = assets::read_module_from_project("car-wash-example", "CarWash");
+
+            // Test that it is not working properly.
+            assert!(MoveModule::publish_module(
+                RuntimeOrigin::signed(bob_addr_32.clone()),
+                car_wash_module.clone(),
+                MAX_GAS_AMOUNT,
+            )
+            .is_err());
+
+            // Update both standard-libraries.
+            assert_ok!(MoveModule::update_stdlib(
+                RuntimeOrigin::root(),
+                move_stdlib,
+            ));
+            assert_ok!(MoveModule::update_stdlib(RuntimeOrigin::root(), sub_stdlib));
+
+            // Test regular functionalities.
+            assert_ok!(MoveModule::publish_module(
+                RuntimeOrigin::signed(bob_addr_32.clone()),
+                car_wash_module,
+                MAX_GAS_AMOUNT,
+            ));
+
+            let script =
+                assets::read_script_from_project("car-wash-example", "initial_coin_minting");
+            let account = bcs::to_bytes(&bob_addr_mv).unwrap();
+            let params: Vec<&[u8]> = vec![&account];
+            let transaction = ScriptTransaction {
+                bytecode: script,
+                type_args: vec![],
+                args: params.iter().map(|x| x.to_vec()).collect(),
+            };
+            let transaction_bc = bcs::to_bytes(&transaction).unwrap();
+            assert_ok!(MoveModule::execute(
+                RuntimeOrigin::signed(bob_addr_32.clone()),
+                transaction_bc,
+                MAX_GAS_AMOUNT,
+                0,
+            ));
+        });
 }


### PR DESCRIPTION
- Added an improved solution for `new_test_ext` -> `ExtBuilder`, but both are still usable
- Added fake standard libraries for testing purposes in `tests/assets/move-projects`
- Implemented two unit tests for extrinsic call `update_stdlib`