### PR TITLE
chore: harmonise base images to avoid different c-lib versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1
-FROM rust:latest as builder
-RUN apt-get update && apt-get upgrade -y && apt-get install -y protobuf-compiler make gcc g++ curl clang
+FROM ubuntu:22.04 as builder
+WORKDIR /root
+RUN apt-get update && apt-get upgrade -y && apt-get install -y build-essential protobuf-compiler make gcc g++ curl clang git
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.73.0
+ENV PATH=/root/.cargo/bin:$PATH
 WORKDIR /usr/src/move
 RUN git clone https://github.com/eigerco/substrate-move.git 
 RUN git clone https://github.com/eigerco/pallet-move.git
@@ -8,7 +11,7 @@ RUN git clone https://github.com/eigerco/substrate-node-template-move-vm-test.gi
 RUN ./substrate-move/scripts/dev_setup.sh -bypt && cargo install --git https://github.com/eigerco/smove
 RUN cd substrate-node-template-move-vm-test && cargo b -r --features runtime-benchmarks
 
-FROM debian:bullseye-slim
+FROM ubuntu:22.04
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/move/substrate-node-template-move-vm-test/target/release/node-template /usr/local/bin/node-template
 EXPOSE 9333 9944 30333


### PR DESCRIPTION
- Until now we used two different base images for building the node and for the final image
- This can lead to an error when the two base images update to different C-library versions
- Switched both base images to Ubuntu-22.04 to avoid that effect