### PR TITLE
feat: add memory protection for core address

### DIFF
--- a/tests/address.rs
+++ b/tests/address.rs
@@ -9,7 +9,8 @@ mod account_convert_tests {
 
     use super::mock::*;
 
-    const DATASET: &[(&str, &str); 6] = &[
+    // This dataset contains only allowed and unprotected memory addressses.
+    const DATASET: &[(&str, &str); 5] = &[
         (
             "gkQ5K6EnLRgZkwozG8GiBAEnJyM6FxzbSaSmVhKJ2w8FcK7ih",
             "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
@@ -17,10 +18,6 @@ mod account_convert_tests {
         (
             "gkNW9pAcCHxZrnoVkhLkEQtsLsW5NWTC75cdAdxAMs9LNYCYg",
             "8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
-        ),
-        (
-            "gkKH52LJ2UumhVBim1n3mCsSj3ctj3GkV8JLVLdhJakxmEDcq",
-            "0000000000000000000000000000000000000000000000000000000000000001",
         ),
         (
             "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
@@ -77,5 +74,19 @@ mod account_convert_tests {
                 .to_vec();
             assert_eq!(bytes_expected, bytes);
         }
+    }
+
+    #[test]
+    fn check_protected_address_errors() {
+        new_test_ext().execute_with(|| {
+            // Check the one protected and prohibited memory address for an error.
+            // The ss58-address is equivalent to Move-address "0x1".
+            let prohibited = "gkKH52LJ2UumhVBim1n3mCsSj3ctj3GkV8JLVLdhJakxmEDcq";
+            let pk_expected = Public::from_ss58check_with_version(prohibited)
+                .unwrap()
+                .0
+                .into();
+            assert!(MoveModule::to_move_address(&pk_expected).is_err());
+        });
     }
 }

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -161,7 +161,7 @@ fn raw_publish_module_dry_run() {
         let module = assets::read_module_from_project("using_stdlib_natives", "Vector");
 
         let estimation =
-            MoveModule::raw_publish_module(&BOB_ADDR_NATIVE, module.clone(), GasStrategy::DryRun)
+            MoveModule::raw_publish_module(&BOB_ADDR_MOVE, module.clone(), GasStrategy::DryRun)
                 .expect("failed to publish a module")
                 .gas_used;
 
@@ -194,7 +194,7 @@ fn raw_publish_bundle_dry_run() {
             assets::read_bundle_from_project("using_stdlib_natives", "using_stdlib_natives");
 
         let estimation =
-            MoveModule::raw_publish_bundle(&BOB_ADDR_NATIVE, bundle.clone(), GasStrategy::DryRun)
+            MoveModule::raw_publish_bundle(&BOB_ADDR_MOVE, bundle.clone(), GasStrategy::DryRun)
                 .expect("failed to publish a bundle")
                 .gas_used;
 


### PR DESCRIPTION
- Implemented memory protection for Move core address
- Protection mechanism is now within `to_move_address` method
- The two methods `raw_publish_module` and `raw_publish_bundle` now getting `AccountAddress` passed instead of `T::AccountID`