### PR TITLE
feat: implement clean up mechanism and add unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6", default-features = fa
 hashbrown = { version = "0.14" }
 hex = { version = "0.4", default-features = false }
 jsonrpsee = { version = "0.16", features = ["server", "macros"] }
+log = { version = "0.4", default-features = false }
 rand = { version = "0.8", default-features = false }
 scale-info = { version = "2.10", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/pallet/Cargo.toml
+++ b/pallet/Cargo.toml
@@ -19,6 +19,7 @@ hashbrown = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+log = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-backend = { workspace = true }
 move-vm-backend-common = { workspace = true }

--- a/pallet/src/tests/assets/move-projects/multiple-signers/build.sh
+++ b/pallet/src/tests/assets/move-projects/multiple-signers/build.sh
@@ -3,12 +3,12 @@ cd $(dirname $0)
 # Participants SS58-addresses.
 BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
 ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-CHARLIE=5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
+DAVE=5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy
 EVE=5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw
 # Build the Move sources.
 smove build
 # Generate script-transactions.
 # 1. init_module(Bob)
 smove create-transaction --compiled-script-path build/multiple-signers/bytecode_scripts/init_module.mv --args signer:$BOB
-# 2. rent_apartment(Alice, Alice-Stash, Bob-Stash)
-smove create-transaction --compiled-script-path build/multiple-signers/bytecode_scripts/rent_apartment.mv --args signer:$ALICE signer:$CHARLIE signer:$EVE
+# 2. rent_apartment(Alice, Dave, Eve, 2)
+smove create-transaction --compiled-script-path build/multiple-signers/bytecode_scripts/rent_apartment.mv --args signer:$ALICE signer:$DAVE signer:$EVE u8:2

--- a/pallet/src/tests/assets/move-projects/smove-build-all.sh
+++ b/pallet/src/tests/assets/move-projects/smove-build-all.sh
@@ -8,6 +8,7 @@ build_dir=(
     "car-wash-example"
     "get-resource"
     "move-basics"
+    "multiple-signers"
     "signer-scripts"
 )
 bundle_dir=(

--- a/pallet/src/tests/assets/move-projects/smove-clean-all.sh
+++ b/pallet/src/tests/assets/move-projects/smove-clean-all.sh
@@ -9,6 +9,7 @@ build_dir=(
     "car-wash-example"
     "get-resource"
     "move-basics"
+    "multiple-signers"
     "signer-scripts"
     # Bundles
     "testing-move-stdlib"

--- a/pallet/src/weights.rs
+++ b/pallet/src/weights.rs
@@ -40,6 +40,7 @@ pub trait WeightInfo {
 	fn publish_module_bundle() -> Weight;
     fn update_stdlib() -> Weight;
     fn execute_as_multi() -> Weight;
+    fn chore_multisig_storage() -> Weight;
 }
 
 /// Weights for pallet_move using the Substrate node and recommended hardware.
@@ -72,6 +73,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn execute_as_multi() -> Weight {
         Weight::from_parts(1_000_000, 0)
     }
+    fn chore_multisig_storage() -> Weight {
+        Weight::from_parts(1_000_000, 0)
+    }
 }
 
 // For backwards compatibility and tests.
@@ -101,6 +105,9 @@ impl WeightInfo for () {
         Weight::from_parts(1_000_000, 0)
     }
     fn execute_as_multi() -> Weight {
+        Weight::from_parts(1_000_000, 0)
+    }
+    fn chore_multisig_storage() -> Weight {
         Weight::from_parts(1_000_000, 0)
     }
 }


### PR DESCRIPTION
- implemented hook `on_idle` as a clean-up mechanism for old multi-sign requests
- added two unit tests for multi-signing situations with event-checking
- restored state of unit tests with eight signers and updated them to the current state of development