### PR TITLE
feat: implement currency locking and extend testing

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -3,7 +3,7 @@ name: Common jobs (fmt, clippy, test)
 on:
   pull_request:
     paths:
-      - src/**
+      - pallet/**
       - Cargo.toml
       - rpc/**
       - .github/workflows/common.yml

--- a/pallet/src/mock.rs
+++ b/pallet/src/mock.rs
@@ -1,4 +1,6 @@
 use frame_support::{
+    dispatch::DispatchErrorWithPostInfo,
+    pallet_prelude::{DispatchError, DispatchResultWithPostInfo},
     parameter_types,
     traits::{ConstU128, ConstU16, ConstU32, ConstU64, OnFinalize, OnIdle, OnInitialize},
 };
@@ -179,6 +181,22 @@ pub(crate) fn roll_to(n: BlockNumberFor<Test>) {
 
 pub(crate) fn last_event() -> RuntimeEvent {
     System::events().pop().expect("Event expected").event
+}
+
+pub(crate) fn verify_module_error_with_msg(
+    res: DispatchResultWithPostInfo,
+    e_msg: &str,
+) -> Result<bool, String> {
+    if let Err(DispatchErrorWithPostInfo {
+        error: DispatchError::Module(moderr),
+        ..
+    }) = res
+    {
+        if let Some(msg) = moderr.message {
+            return Ok(msg == e_msg);
+        }
+    }
+    Err(format!("{res:?} does not match '{e_msg}'"))
 }
 
 pub mod assets {

--- a/pallet/src/tests/update_stdlib.rs
+++ b/pallet/src/tests/update_stdlib.rs
@@ -3,9 +3,7 @@
 use crate::mock::*;
 use crate::{no_type_args, script_transaction};
 
-use frame_support::{
-    assert_err, assert_ok, dispatch::DispatchErrorWithPostInfo, pallet_prelude::*,
-};
+use frame_support::{assert_err, assert_ok, pallet_prelude::*};
 use move_stdlib::move_stdlib_bundle;
 use move_vm_backend::types::MAX_GAS_AMOUNT;
 
@@ -15,22 +13,6 @@ fn mock_move_stdlib() -> Vec<u8> {
 
 fn mock_substrate_stdlib() -> Vec<u8> {
     assets::read_bundle_from_project("testing-substrate-stdlib", "testing-substrate-stdlib")
-}
-
-fn verify_module_error_with_msg(
-    res: DispatchResultWithPostInfo,
-    e_msg: &str,
-) -> Result<bool, String> {
-    if let Err(DispatchErrorWithPostInfo {
-        error: DispatchError::Module(moderr),
-        ..
-    }) = res
-    {
-        if let Some(msg) = moderr.message {
-            return Ok(msg == e_msg);
-        }
-    }
-    Err(format!("{res:?} does not match '{e_msg}'"))
 }
 
 #[test]


### PR DESCRIPTION
- implemented currency locking in case of multi-signer execution requests
- extended existing unit tests for checking this implementation
- added a new unit test about checking the cheque limit in case of multi-signer requests
- fixed the GitHub CI action because otherwise, the checks wouldn't have been triggered in this PR