### PR TITLE
feat: remove unnecessary parameters for gas estimation

### DIFF
--- a/pallet/src/api.rs
+++ b/pallet/src/api.rs
@@ -37,7 +37,7 @@ sp_api::decl_runtime_apis! {
         fn estimate_gas_publish_bundle(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, DispatchError>;
 
         // Estimate gas for script execution.
-        fn estimate_gas_execute_script(account: AccountId, transaction: Vec<u8>, cheque_limit: u128) -> Result<MoveApiEstimation, DispatchError>;
+        fn estimate_gas_execute_script(transaction: Vec<u8>) -> Result<MoveApiEstimation, DispatchError>;
 
         // Get module binary by its address.
         fn get_module(address: String, name: String) -> Result<Option<Vec<u8>>, Vec<u8>>;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -64,9 +64,7 @@ pub trait MoveApi<BlockHash, AccountId> {
     #[method(name = "mvm_estimateGasExecuteScript")]
     fn estimate_gas_execute_script(
         &self,
-        account: AccountId,
         transaction: Vec<u8>,
-        cheque_limit: u128,
         at: Option<BlockHash>,
     ) -> RpcResult<Estimation>;
 
@@ -177,18 +175,14 @@ where
 
     fn estimate_gas_execute_script(
         &self,
-        account: AccountId,
         transaction: Vec<u8>,
-        cheque_limit: u128,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Estimation> {
         let api = self.client.runtime_api();
         let res = api
             .estimate_gas_execute_script(
                 at.unwrap_or_else(|| self.client.info().best_hash),
-                account,
                 transaction,
-                cheque_limit,
             )
             .map_err(runtime_error_into_rpc_err)?;
 


### PR DESCRIPTION
- when estimating gas for a script execution, two unnecessary parameters are passed
- this PR removes them from the RPC-ABI