### PR TITLE
feat: harmonised helper scripts and removed scripts with requirements

### DIFF
--- a/pallet/src/assets/move-projects/car-wash-example/build.sh
+++ b/pallet/src/assets/move-projects/car-wash-example/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd $(dirname $0)
 # Build the project
 smove build
 # Create all Script-Transactions

--- a/pallet/src/assets/move-projects/car-wash-example/estimate-gas-scripts.sh
+++ b/pallet/src/assets/move-projects/car-wash-example/estimate-gas-scripts.sh
@@ -1,4 +1,0 @@
-#! /usr/bin/sh
-cd $(dirname $0)
-# Estimate needed gas
-smove node rpc estimate-gas-execute-script -s build/multiple-signers/script_transactions/rent_apartment.mvt

--- a/pallet/src/assets/move-projects/car-wash-example/hints.md
+++ b/pallet/src/assets/move-projects/car-wash-example/hints.md
@@ -5,7 +5,7 @@
 Requirement: Before publishing the module for user _Bob_.
 
 ```sh
-smove node rpc estimate-gas-publish-module --account-id 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty --module-path build/car-wash-example/bytecode_modules/CarWash.mv
+smove node rpc estimate-gas-publish-module -a 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty -m build/car-wash-example/bytecode_modules/CarWash.mv
 ```
 
 ### Estimate Gas for Script `initial_coin_minting`

--- a/pallet/src/assets/move-projects/multiple-signers/estimate.init_module.sh
+++ b/pallet/src/assets/move-projects/multiple-signers/estimate.init_module.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd $(dirname $0)
-# Estimate needed gas for a single script execution.
-smove node rpc estimate-gas-execute-script -s build/multiple-signers/script_transactions/init_module.mvt
-

--- a/pallet/src/assets/move-projects/multiple-signers/estimate.publish_module.sh
+++ b/pallet/src/assets/move-projects/multiple-signers/estimate.publish_module.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd $(dirname $0)
-# Our students who want to rent a dorm together.
-BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-# Estimate needed gas for a single script execution.
-smove node rpc estimate-gas-publish-module -a $BOB -m build/multiple-signers/bytecode_modules/Dorm.mv
-

--- a/pallet/src/assets/move-projects/multiple-signers/estimate.rent_apartment.sh
+++ b/pallet/src/assets/move-projects/multiple-signers/estimate.rent_apartment.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-cd $(dirname $0)
-# Estimate needed gas for a single script execution.
-smove node rpc estimate-gas-execute-script -s build/multiple-signers/script_transactions/rent_apartment.mvt

--- a/pallet/src/assets/move-projects/multiple-signers/hints.md
+++ b/pallet/src/assets/move-projects/multiple-signers/hints.md
@@ -1,0 +1,23 @@
+# Shell Snippets
+
+### Estimate Gas for Module `Dorm`
+
+Requirement: Before publishing the module for user _Bob_.
+
+```sh
+smove node rpc estimate-gas-publish-module -a 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty -m build/multiple-signers/bytecode_modules/Dorm.mv
+```
+
+### Estimate Gas for Script `init_module`
+
+Requirement: After publishing the module for user _Bob_.
+```sh
+smove node rpc estimate-gas-execute-script -s build/multiple-signers/script_transactions/init_module.mvt
+```
+
+### Estimate Gas for Script `rent_apartment`
+
+Requirement: After publishing the module for user _Bob_ and initializing the module with `init_module`.
+```sh
+smove node rpc estimate-gas-execute-script -s build/multiple-signers/script_transactions/rent_apartment.mvt
+```

--- a/pallet/src/assets/move-projects/smove-build-all.sh
+++ b/pallet/src/assets/move-projects/smove-build-all.sh
@@ -1,4 +1,4 @@
-# #!/bin/bash
+#!/bin/bash
 
 # Position the cwd in the same folder with the script (where the below folders are located)
 cd $(dirname $0)
@@ -18,13 +18,19 @@ bundle_dir=(
 )
 
 # Build simple packages
-for i in "${build_dir[@]}"; do
-    echo $i
-    smove build -p $i
+for dir in "${build_dir[@]}"; do
+    echo $dir
+    build_script=$dir"/build.sh"
+    if [ -f "$build_script" ];
+    then
+        sh $build_script
+    else
+        smove build -p $dir
+    fi
 done
 
 # Build bundles
-for i in "${bundle_dir[@]}"; do
-    echo $i
-    smove bundle -p $i
+for dir in "${bundle_dir[@]}"; do
+    echo $dir
+    smove bundle -p $dir
 done

--- a/pallet/src/assets/move-projects/smove-script-weights-exec.sh
+++ b/pallet/src/assets/move-projects/smove-script-weights-exec.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Note: Modules CarWash (car-wash-example) and Dorm (multiple-signers) have to be published first!
-cd $(dirname $0)
-# Estimate needed gas for a single script execution.
-smove node rpc estimate-gas-execute-script -s car-wash-example/build/car-wash-example/script_transactions/register_new_user.mvt
-smove node rpc estimate-gas-execute-script -s car-wash-example/build/car-wash-example/script_transactions/buy_coin.mvt
-smove node rpc estimate-gas-execute-script -s car-wash-example/build/car-wash-example/script_transactions/wash_car.mvt
-smove node rpc estimate-gas-execute-script -s multiple-signers/build/multiple-signers/script_transactions/rent_apartment.mvt

--- a/pallet/src/assets/move-projects/smove-script-weights-init.sh
+++ b/pallet/src/assets/move-projects/smove-script-weights-init.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# Note: Modules CarWash (car-wash-example) and Dorm (multiple-signers) have to be published first!
-cd $(dirname $0)
-# Estimate needed gas for a single script execution.
-smove node rpc estimate-gas-execute-script -s car-wash-example/build/car-wash-example/script_transactions/initial_coin_minting.mvt
-smove node rpc estimate-gas-execute-script -s multiple-signers/build/multiple-signers/script_transactions/init_module.mvt


### PR DESCRIPTION
- all build-scripts are now named `build.sh`
- main scrips in `move-projects` do now check if there is such a `build.rs` before applying `smove build/bundle`
- helper scripts that do work only in certain conditions, are transformed into hint files `Hints.md`