### PR TITLE
chore: harmonise naming style in Move stdlibs

### DIFF
--- a/pallet/src/assets/move-projects/balance/Move.toml
+++ b/pallet/src/assets/move-projects/balance/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 
 [dependencies]
 MoveStdlib = { git = "https://github.com/eigerco/move-stdlib", rev = "main" }
-substrate-stdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
+SubstrateStdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
 
 [addresses]
 std = "0x1"

--- a/pallet/src/assets/move-projects/car-wash-example/Move.toml
+++ b/pallet/src/assets/move-projects/car-wash-example/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 
 [dependencies]
 MoveStdlib = { git = "https://github.com/eigerco/move-stdlib", rev = "main" }
-substrate-stdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
+SubstrateStdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
 
 [addresses]
 std =  "0x1"

--- a/pallet/src/assets/move-projects/multiple-signers/Move.toml
+++ b/pallet/src/assets/move-projects/multiple-signers/Move.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 [dependencies]
 MoveStdlib = { git = "https://github.com/eigerco/move-stdlib", rev = "main" }
-substrate-stdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
+SubstrateStdlib = { git = "https://github.com/eigerco/substrate-stdlib.git", rev = "main" }
 
 [addresses]
 std =  "0x1"


### PR DESCRIPTION
- harmonise naming style in Move-stdlibs, here: `SubstrateStdlib`