### PR TITLE
feat: remove rpc methods about gas weight relations

### DIFF
--- a/pallet/src/api.rs
+++ b/pallet/src/api.rs
@@ -14,6 +14,9 @@ pub struct MoveApiEstimation {
     pub gas_used: u64,
     /// Status code for the MoveVM execution.
     pub vm_status_code: u64,
+    /// Substrate weight required for the complete extrinsic cost combined with the variable gas
+    /// indicated in the `Estimaton` struct.
+    pub total_weight_including_gas_used: Weight,
 }
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
@@ -22,12 +25,6 @@ sp_api::decl_runtime_apis! {
     pub trait MoveApi<AccountId> where      // AccountID is already here for the next API calls.
         AccountId: codec::Codec,
     {
-        // Convert Weight to Gas.
-        fn gas_to_weight(gas_limit: u64) -> Weight;
-
-        // Convert Gas to Weight.
-        fn weight_to_gas(weight: Weight) -> u64;
-
         // Estimate gas for publishing a module.
         fn estimate_gas_publish_module(account: AccountId, bytecode: Vec<u8>) -> Result<MoveApiEstimation, DispatchError>;
 

--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -646,16 +646,6 @@ pub mod pallet {
 
     // RPC method implementation for simple node integration.
     impl<T: Config> Pallet<T> {
-        pub fn rpc_gas_to_weight(_gas_limit: u64) -> Weight {
-            // TODO (eiger): implement in M3
-            Weight::from_parts(1_123_123, 0) // Hardcoded for testing
-        }
-
-        pub fn rpc_weight_to_gas(_weight: Weight) -> u64 {
-            // TODO (eiger): implement in M3
-            100
-        }
-
         pub fn rpc_estimate_gas_publish_module(
             account: &T::AccountId,
             bytecode: Vec<u8>,
@@ -666,6 +656,9 @@ pub mod pallet {
             Ok(MoveApiEstimation {
                 vm_status_code: vm_result.status_code.into(),
                 gas_used: vm_result.gas_used,
+                total_weight_including_gas_used: T::WeightInfo::publish_module(
+                    vm_result.gas_used as u32,
+                ),
             })
         }
 
@@ -679,6 +672,7 @@ pub mod pallet {
             Ok(MoveApiEstimation {
                 vm_status_code: vm_result.status_code.into(),
                 gas_used: vm_result.gas_used,
+                total_weight_including_gas_used: T::WeightInfo::publish_module_bundle(),
             })
         }
 
@@ -713,6 +707,7 @@ pub mod pallet {
             Ok(MoveApiEstimation {
                 vm_status_code: vm_result.status_code.into(),
                 gas_used: vm_result.gas_used,
+                total_weight_including_gas_used: T::WeightInfo::execute(vm_result.gas_used as u32),
             })
         }
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use codec::Codec;
-use frame_support::weights::Weight;
 use jsonrpsee::{
     core::{Error as JsonRpseeError, RpcResult},
     proc_macros::rpc,
@@ -34,14 +33,6 @@ impl From<MoveApiEstimation> for Estimation {
 /// Public RPC API of the Move pallet.
 #[rpc(server)]
 pub trait MoveApi<BlockHash, AccountId> {
-    /// Convert gas to weight.
-    #[method(name = "mvm_gasToWeight")]
-    fn gas_to_weight(&self, gas: u64, at: Option<BlockHash>) -> RpcResult<Weight>;
-
-    /// Convert weight to gas.
-    #[method(name = "mvm_weightToGas")]
-    fn weight_to_gas(&self, weight: Weight, at: Option<BlockHash>) -> RpcResult<u64>;
-
     /// Estimate gas for publishing module.
     #[method(name = "mvm_estimateGasPublishModule")]
     fn estimate_gas_publish_module(
@@ -119,20 +110,6 @@ where
     C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
     C::Api: MoveRuntimeApi<Block, AccountId>,
 {
-    fn gas_to_weight(&self, gas: u64, at: Option<<Block as BlockT>::Hash>) -> RpcResult<Weight> {
-        let api = self.client.runtime_api();
-        let res = api.gas_to_weight(at.unwrap_or_else(|| self.client.info().best_hash), gas);
-
-        res.map_err(runtime_error_into_rpc_err)
-    }
-
-    fn weight_to_gas(&self, weight: Weight, at: Option<<Block as BlockT>::Hash>) -> RpcResult<u64> {
-        let api = self.client.runtime_api();
-        let res = api.weight_to_gas(at.unwrap_or_else(|| self.client.info().best_hash), weight);
-
-        res.map_err(runtime_error_into_rpc_err)
-    }
-
     fn estimate_gas_publish_module(
         &self,
         account: AccountId,


### PR DESCRIPTION
- removed RPC methods about gas-to-weight relations since they are not fixed
- added total weight including gas costs to `MoveApiEstimation`