### PR TITLE
feat: extend unit test to cover multi-signer execution fail

### DIFF
--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -755,8 +755,6 @@ pub mod pallet {
         InvalidScriptTransaction,
         /// User tried to publish module in a protected memory area.
         StdlibAddressNotAllowed,
-        /// Error about signing multi-signature execution request twice.
-        UserHasAlreadySigned,
         /// Script contains more signers than allowed maximum number of signers.
         MaxSignersExceeded,
         /// No space left in the ChoreOnIdleStorage during this block.

--- a/pallet/src/signer.rs
+++ b/pallet/src/signer.rs
@@ -44,7 +44,6 @@ pub enum SigDataError {
     MaxSignersExceeded,
     ScriptSignatureFailure,
     UnableToDeserializeAccount,
-    UserHasAlreadySigned,
 }
 
 impl<T> From<SigDataError> for Error<T> {
@@ -53,7 +52,6 @@ impl<T> From<SigDataError> for Error<T> {
             SigDataError::MaxSignersExceeded => Error::<T>::MaxSignersExceeded,
             SigDataError::ScriptSignatureFailure => Error::<T>::ScriptSignatureFailure,
             SigDataError::UnableToDeserializeAccount => Error::<T>::UnableToDeserializeAccount,
-            SigDataError::UserHasAlreadySigned => Error::<T>::UserHasAlreadySigned,
         }
     }
 }
@@ -203,9 +201,9 @@ impl<T: Config + SysConfig> ScriptSignatureHandler<T> {
             return Err(Error::<T>::UnexpectedUserSignature);
         };
 
-        // User can sign only once.
+        // Signing again will update the setup parameters.
         if matches!(ms_data.signature, Signature::Approved) {
-            return Err(Error::<T>::UserHasAlreadySigned);
+            T::Currency::remove_lock(ms_data.lock_id, account);
         }
 
         ms_data.signature = Signature::Approved;


### PR DESCRIPTION
- we remove the `UserHasAlreadySigned`-event to introduce a simpler and more comfortable approach
- provide the possibility to update the signing data in case of multiple signing execution requests