### PR TITLE
fix: add project gas-costs-bundle to build process for benchmarks

### DIFF
--- a/pallet/src/assets/move-projects/gas-costs-bundles/build.sh
+++ b/pallet/src/assets/move-projects/gas-costs-bundles/build.sh
@@ -25,7 +25,7 @@ function create_move_project() {
     smove bundle -p $NAME
 }
 
-rm -rf bundle*
+sh ./clean.sh
 for i in $(seq 1 $ITERATIONS)
 do
     create_move_project $i

--- a/pallet/src/assets/move-projects/gas-costs-bundles/clean.sh
+++ b/pallet/src/assets/move-projects/gas-costs-bundles/clean.sh
@@ -1,0 +1,3 @@
+# #!/bin/bash
+cd $(dirname $0)
+rm -rf bundle*

--- a/pallet/src/assets/move-projects/smove-build-all.sh
+++ b/pallet/src/assets/move-projects/smove-build-all.sh
@@ -14,15 +14,15 @@ build_dir=(
     "signer-scripts"
 )
 bundle_dir=(
+    "base58_smove_build"
+    "basic_coin"
+    "car-wash-example"
+    "gas-costs-bundles"
+    "multiple-signers"
     "prohibited-bundle"
     "testing-move-stdlib"
     "testing-substrate-stdlib"
     "using_stdlib_natives"
-
-    "car-wash-example"
-    "multiple-signers"
-    "base58_smove_build"
-    "basic_coin"
 )
 
 

--- a/pallet/src/assets/move-projects/smove-clean-all.sh
+++ b/pallet/src/assets/move-projects/smove-clean-all.sh
@@ -6,21 +6,28 @@ cd $(dirname $0)
 build_dir=(
     "balance"
     "base58_smove_build"
+    "basic_coin"
     "car-wash-example"
     "gas-costs"
+    "gas-costs-bundles"
     "get-resource"
     "move-basics"
     "multiple-signers"
-    "signer-scripts"
-    "basic_coin"
     "prohibited-bundle"
+    "signer-scripts"
     "testing-move-stdlib"
     "testing-substrate-stdlib"
     "using_stdlib_natives"
 )
 
 # Clean build directories.
-for i in "${build_dir[@]}"; do
-    echo $i
-    rm -rf "$i/build"
+for dir in "${build_dir[@]}"; do
+    echo $dir
+    clean_script=$dir"/clean.sh"
+    if [ -f "$clean_script" ];
+    then
+        sh $clean_script
+    else
+        rm -rf "$dir/build"
+    fi
 done


### PR DESCRIPTION
- Move project `gas-costs-bundle` was missing in the build process
- modified shell scripts for building and cleaning to work properly