### PR TITLE
fix: sh functions do not use `function` prefix on Linux

### DIFF
--- a/pallet/src/assets/move-projects/gas-costs-bundles/build.sh
+++ b/pallet/src/assets/move-projects/gas-costs-bundles/build.sh
@@ -3,7 +3,7 @@ cd $(dirname $0)
 
 ITERATIONS=25
 
-function write_module() {
+write_module() {
     printf "module AiBob::CalMod$2 {\n" >> $1
     printf "    fun fun_fun(a: u8) {\n" >> $1
     printf "        assert!(a == 0, 0);\n" >> $1
@@ -11,7 +11,7 @@ function write_module() {
     printf "}\n" >> $1
 }
 
-function create_move_project() {
+create_move_project() {
     NAME=bundle$1
     smove new $NAME
     TOML=$NAME/Move.toml

--- a/pallet/src/assets/move-projects/gas-costs/gen_cal_scripts.sh
+++ b/pallet/src/assets/move-projects/gas-costs/gen_cal_scripts.sh
@@ -6,7 +6,7 @@ ITERATIONS=25
 ALICE=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 BOB=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
 
-function write_smove_cmd() {
+write_smove_cmd() {
     cp build/gas-costs/bytecode_scripts/mint.mv build/gas-costs/bytecode_scripts/mint_$1.mv
     printf "\nsmove create-transaction -c build/gas-costs/bytecode_scripts/mint_$1.mv --args signer:$BOB address:$ALICE u64:$1" >> $BASH_SH
 }


### PR DESCRIPTION
Seems like the behavior in `sh` is not aligned between OSX and Linux. On Linux, sh script functions are not supposed to be prefixed with the `function` keyword.