### PR TITLE
fix: update dockerfile and simplify it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:22.04 as builder
 WORKDIR /root
-RUN apt-get update && apt-get upgrade -y && apt-get install -y build-essential protobuf-compiler make gcc g++ curl clang git
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.73.0
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y build-essential make gcc g++ curl clang git libssl-dev pkg-config protobuf-compiler
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
 WORKDIR /usr/src/move
-RUN git clone https://github.com/eigerco/substrate-move.git 
+RUN cargo install --git https://github.com/eigerco/smove
 RUN git clone https://github.com/eigerco/pallet-move.git
 RUN git clone https://github.com/eigerco/substrate-node-template-move-vm-test.git --branch pallet-move
-RUN ./substrate-move/scripts/dev_setup.sh -bypt && cargo install --git https://github.com/eigerco/smove
-RUN cd substrate-node-template-move-vm-test && cargo b -r --features runtime-benchmarks
+RUN cd substrate-node-template-move-vm-test && cargo b -r
 
 FROM ubuntu:22.04
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- removed dev-setup from substrate-move
- removed checkout of substrate-move
- added two packages on Linux setup instead
- removed `--feature runtime-benchmarks` from node compilation