### PR TITLE
docs: update docs to reflect the chances

### DIFF
--- a/doc/tech_guide.md
+++ b/doc/tech_guide.md
@@ -13,9 +13,8 @@ In this tech guide, you will find instructions and details on:
 
 Compile the template-node and launch locally by:
 
-1. Clone Move pallet and node-template (make sure they are in the same directory):
+1. Clone the node-template:
    ```bash
-   git clone https://github.com/eigerco/pallet-move.git
    git clone https://github.com/eigerco/substrate-node-template-move-vm-test --branch pallet-move
    ```
 


### PR DESCRIPTION
I’ve updated the template to use pallet-move dependencies from a remote Git repository instead of local references, making it easier for others to collaborate and reproduce the project. 
This is the corresponding update on the docs to reflect that change.